### PR TITLE
VFB-52: Add generate maps action in parcels page

### DIFF
--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -38,7 +38,8 @@ type ActionName =
     | "Download Shopping Lists"
     | "Download Driver Overview"
     | "Download Day Overview"
-    | "Delete Parcel Request";
+    | "Delete Parcel Request"
+    | "Generate Map";
 
 type AvailableActionsType = {
     [actionKey in ActionName]: {
@@ -81,14 +82,14 @@ const availableActions: AvailableActionsType = {
         errorMessage: "Please select at least one parcel.",
         actionType: "deleteParcel",
     },
-};
-
-const generateMapAction = {
     "Generate Map": {
+        showSelectedParcelsInModal: false,
         errorCondition: isNotAtLeastOne,
         errorMessage: "Please select at least one parcel.",
+        actionType: "generateMap",
     },
 };
+
 interface ActionsInputComponentProps {
     actionName: ActionName;
     selectedParcels: ParcelsTableRow[];
@@ -319,27 +320,33 @@ const Actions: React.FC<Props> = ({
                 >
                     <MenuList id="action-menu">
                         {Object.entries(availableActions).map(([key, value]) => {
-                            return (
-                                <MenuItem
-                                    key={key}
-                                    onClick={onMenuItemClick(
-                                        key as ActionName,
-                                        value.errorCondition,
-                                        value.errorMessage
-                                    )}
-                                >
-                                    {key}
-                                </MenuItem>
-                            );
+                            if (key !== "Generate Map") {
+                                return (
+                                    <MenuItem
+                                        key={key}
+                                        onClick={onMenuItemClick(
+                                            key as ActionName,
+                                            value.errorCondition,
+                                            value.errorMessage
+                                        )}
+                                    >
+                                        {key}
+                                    </MenuItem>
+                                );
+                            } else {
+                                return (
+                                    <MenuItem
+                                        key={key}
+                                        onClick={onMapsClick(
+                                            value.errorCondition,
+                                            value.errorMessage
+                                        )}
+                                    >
+                                        {key}
+                                    </MenuItem>
+                                );
+                            }
                         })}
-                        <MenuItem
-                            onClick={onMapsClick(
-                                generateMapAction["Generate Map"].errorCondition,
-                                generateMapAction["Generate Map"].errorMessage
-                            )}
-                        >
-                            Generate Map
-                        </MenuItem>
                     </MenuList>
                 </Menu>
             )}

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -254,6 +254,7 @@ const Actions: React.FC<Props> = ({
         };
     };
 
+
     const mapsLinkForSelectedParcels = (): string => {
         return (
             "https://www.google.com/maps/dir/" +

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -254,7 +254,6 @@ const Actions: React.FC<Props> = ({
         };
     };
 
-
     const mapsLinkForSelectedParcels = (): string => {
         return (
             "https://www.google.com/maps/dir/" +

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -234,16 +234,22 @@ const Actions: React.FC<Props> = ({
     const onMenuItemClick = (
         key: ActionName,
         errorCondition: (value: number) => boolean,
-        errorMessage: string
+        errorMessage: string,
+        shouldOpenM
     ): (() => void) => {
         return () => {
             if (errorCondition(selectedParcels.length)) {
                 setActionAnchorElement(null);
                 setModalError(errorMessage);
             } else {
-                setModalToDisplay(key);
-                setActionAnchorElement(null);
-                setModalError(null);
+                if (key === "Generate Map") {
+                    const mapsLink = mapsLinkForSelectedParcels();
+                    openInNewTab(mapsLink);
+                } else {
+                    setModalToDisplay(key);
+                    setActionAnchorElement(null);
+                    setModalError(null);
+                }
             }
         };
     };
@@ -258,21 +264,6 @@ const Actions: React.FC<Props> = ({
 
     const openInNewTab = (url: string): void => {
         window.open(url, "_blank", "noopener, noreferrer");
-    };
-
-    const onMapsClick = (
-        errorCondition: (value: number) => boolean,
-        errorMessage: string
-    ): (() => void) => {
-        return () => {
-            if (errorCondition(selectedParcels.length)) {
-                setActionAnchorElement(null);
-                setModalError(errorMessage);
-            } else {
-                const mapsLink = mapsLinkForSelectedParcels();
-                openInNewTab(mapsLink);
-            }
-        };
     };
 
     return (
@@ -326,15 +317,12 @@ const Actions: React.FC<Props> = ({
                             return (
                                 <MenuItem
                                     key={key}
-                                    onClick={
-                                        value.shouldOpenModal
-                                            ? onMenuItemClick(
-                                                  key as ActionName,
-                                                  value.errorCondition,
-                                                  value.errorMessage
-                                              ) // eslint-disable-line indent
-                                            : onMapsClick(value.errorCondition, value.errorMessage)
-                                    }
+                                    onClick={onMenuItemClick(
+                                        key as ActionName,
+                                        value.errorCondition,
+                                        value.errorMessage,
+                                        value.shouldOpenModal,
+                                    )}
                                 >
                                     {key}
                                 </MenuItem>

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -333,7 +333,7 @@ const Actions: React.FC<Props> = ({
                                                   key as ActionName,
                                                   value.errorCondition,
                                                   value.errorMessage
-                                            )
+                                              ) // eslint-disable-line indent
                                     }
                                 >
                                     {key}

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -241,12 +241,11 @@ const Actions: React.FC<Props> = ({
     };
 
     const mapsLinkForParcels = (): string => {
-        const mapsLinkList = ["https://www.google.com/maps/dir/"];
-        selectedParcels.map((parcel) => {
-            mapsLinkList.push(parcel.addressPostcode + "/");
+        let mapsLinkString = "https://www.google.com/maps/dir";
+        selectedParcels.forEach((parcel) => {
+            mapsLinkString = mapsLinkString.concat("/", parcel.addressPostcode);
         });
-        mapsLinkList.push("/");
-        const mapsLinkString = mapsLinkList.join("");
+        mapsLinkString = mapsLinkString.concat("//");
         return mapsLinkString;
     };
 

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -47,6 +47,7 @@ type AvailableActionsType = {
         errorCondition: (value: number) => boolean;
         errorMessage: string;
         actionType: ActionType;
+        shouldOpenModal: boolean;
     };
 };
 
@@ -56,18 +57,21 @@ const availableActions: AvailableActionsType = {
         errorCondition: doesNotEqualOne,
         errorMessage: "Please select exactly one parcel.",
         actionType: "pdfDownload",
+        shouldOpenModal: true,
     },
     "Download Shopping Lists": {
         showSelectedParcelsInModal: true,
         errorCondition: isNotAtLeastOne,
         errorMessage: "Please select at least one parcel.",
         actionType: "pdfDownload",
+        shouldOpenModal: true,
     },
     "Download Driver Overview": {
         showSelectedParcelsInModal: true,
         errorCondition: isNotAtLeastOne,
         errorMessage: "Please select at least one parcel.",
         actionType: "pdfDownload",
+        shouldOpenModal: true,
     },
     "Download Day Overview": {
         showSelectedParcelsInModal: false,
@@ -75,18 +79,21 @@ const availableActions: AvailableActionsType = {
         errorMessage:
             "The day overview will show the parcels for a particular date and location. It will show not the currently selected parcel. Please unselect the parcels.",
         actionType: "pdfDownload",
+        shouldOpenModal: true,
     },
     "Delete Parcel Request": {
         showSelectedParcelsInModal: true,
         errorCondition: isNotAtLeastOne,
         errorMessage: "Please select at least one parcel.",
         actionType: "deleteParcel",
+        shouldOpenModal: true,
     },
     "Generate Map": {
         showSelectedParcelsInModal: false,
         errorCondition: isNotAtLeastOne,
         errorMessage: "Please select at least one parcel.",
         actionType: "generateMap",
+        shouldOpenModal: false,
     },
 };
 
@@ -320,32 +327,22 @@ const Actions: React.FC<Props> = ({
                 >
                     <MenuList id="action-menu">
                         {Object.entries(availableActions).map(([key, value]) => {
-                            if (key !== "Generate Map") {
-                                return (
-                                    <MenuItem
-                                        key={key}
-                                        onClick={onMenuItemClick(
-                                            key as ActionName,
-                                            value.errorCondition,
-                                            value.errorMessage
-                                        )}
-                                    >
-                                        {key}
-                                    </MenuItem>
-                                );
-                            } else {
-                                return (
-                                    <MenuItem
-                                        key={key}
-                                        onClick={onMapsClick(
-                                            value.errorCondition,
-                                            value.errorMessage
-                                        )}
-                                    >
-                                        {key}
-                                    </MenuItem>
-                                );
-                            }
+                            return (
+                                <MenuItem
+                                    key={key}
+                                    onClick={
+                                        key === "Generate Map"
+                                            ? onMapsClick(value.errorCondition, value.errorMessage)
+                                            : onMenuItemClick(
+                                                  key as ActionName,
+                                                  value.errorCondition,
+                                                  value.errorMessage
+                                            )
+                                    }
+                                >
+                                    {key}
+                                </MenuItem>
+                            );
                         })}
                     </MenuList>
                 </Menu>

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -257,10 +257,7 @@ const Actions: React.FC<Props> = ({
     };
 
     const openInNewTab = (url: string): void => {
-        const newWindow = window.open(url, "_blank", "noopener, noreferrer");
-        if (newWindow) {
-            newWindow.opener = null;
-        }
+        window.open(url, "_blank", "noopener, noreferrer");
     };
 
     const onMapsClick = (

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -248,13 +248,12 @@ const Actions: React.FC<Props> = ({
         };
     };
 
-    const mapsLinkForParcels = (): string => {
-        let mapsLinkString = "https://www.google.com/maps/dir";
-        selectedParcels.forEach((parcel) => {
-            mapsLinkString = mapsLinkString.concat("/", parcel.addressPostcode);
-        });
-        mapsLinkString = mapsLinkString.concat("//");
-        return mapsLinkString;
+    const mapsLinkForSelectedParcels = (): string => {
+        return (
+            "https://www.google.com/maps/dir/" +
+            selectedParcels.map((parcel) => parcel.addressPostcode.replaceAll(" ", "")).join("/") +
+            "//"
+        );
     };
 
     const openInNewTab = (url: string): void => {
@@ -273,7 +272,7 @@ const Actions: React.FC<Props> = ({
                 setActionAnchorElement(null);
                 setModalError(errorMessage);
             } else {
-                const mapsLink = mapsLinkForParcels();
+                const mapsLink = mapsLinkForSelectedParcels();
                 openInNewTab(mapsLink);
             }
         };

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -235,14 +235,14 @@ const Actions: React.FC<Props> = ({
         key: ActionName,
         errorCondition: (value: number) => boolean,
         errorMessage: string,
-        shouldOpenM
+        shouldOpenModal: boolean
     ): (() => void) => {
         return () => {
             if (errorCondition(selectedParcels.length)) {
                 setActionAnchorElement(null);
                 setModalError(errorMessage);
             } else {
-                if (key === "Generate Map") {
+                if (!shouldOpenModal) {
                     const mapsLink = mapsLinkForSelectedParcels();
                     openInNewTab(mapsLink);
                 } else {
@@ -321,7 +321,7 @@ const Actions: React.FC<Props> = ({
                                         key as ActionName,
                                         value.errorCondition,
                                         value.errorMessage,
-                                        value.shouldOpenModal,
+                                        value.shouldOpenModal
                                     )}
                                 >
                                     {key}

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import Menu from "@mui/material/Menu/Menu";
 import MenuList from "@mui/material/MenuList/MenuList";
 import MenuItem from "@mui/material/MenuItem/MenuItem";
@@ -271,10 +271,6 @@ const Actions: React.FC<Props> = ({
             }
         };
     };
-
-    useEffect(() => {
-        console.log(mapsLinkForParcels());
-    }, [selectedParcels]);
 
     return (
         <>

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -327,13 +327,13 @@ const Actions: React.FC<Props> = ({
                                 <MenuItem
                                     key={key}
                                     onClick={
-                                        key === "Generate Map"
-                                            ? onMapsClick(value.errorCondition, value.errorMessage)
-                                            : onMenuItemClick(
+                                        value.shouldOpenModal
+                                            ? onMenuItemClick(
                                                   key as ActionName,
                                                   value.errorCondition,
                                                   value.errorMessage
                                               ) // eslint-disable-line indent
+                                            : onMapsClick(value.errorCondition, value.errorMessage)
                                     }
                                 >
                                     {key}

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -202,7 +202,7 @@ const Actions: React.FC<Props> = ({
     modalError,
     setModalError,
 }) => {
-    const [selectedAction, setSelectedAction] = useState<ActionName | null>(null);
+    const [modalToDisplay, setModalToDisplay] = useState<ActionName | null>(null);
     const [labelQuantity, setLabelQuantity] = useState<number>(0);
     const [date, setDate] = useState(dayjs());
     const [driverName, setDriverName] = useState("");
@@ -225,7 +225,7 @@ const Actions: React.FC<Props> = ({
     };
 
     const onModalClose = (): void => {
-        setSelectedAction(null);
+        setModalToDisplay(null);
         setModalError(null);
         setDate(dayjs());
         setDriverName("");
@@ -241,7 +241,7 @@ const Actions: React.FC<Props> = ({
                 setActionAnchorElement(null);
                 setModalError(errorMessage);
             } else {
-                setSelectedAction(key);
+                setModalToDisplay(key);
                 setActionAnchorElement(null);
                 setModalError(null);
             }
@@ -279,7 +279,7 @@ const Actions: React.FC<Props> = ({
         <>
             {Object.entries(availableActions).map(([key, value]) => {
                 return (
-                    selectedAction === key && (
+                    modalToDisplay === key && (
                         <ActionsModal
                             key={key}
                             showSelectedParcels={value.showSelectedParcelsInModal}
@@ -304,7 +304,7 @@ const Actions: React.FC<Props> = ({
                             }
                         >
                             <ActionsButton
-                                pdfType={selectedAction}
+                                pdfType={modalToDisplay}
                                 selectedParcels={selectedParcels}
                                 date={date}
                                 labelQuantity={labelQuantity}

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Menu from "@mui/material/Menu/Menu";
 import MenuList from "@mui/material/MenuList/MenuList";
 import MenuItem from "@mui/material/MenuItem/MenuItem";
@@ -83,6 +83,12 @@ const availableActions: AvailableActionsType = {
     },
 };
 
+const generateMapAction = {
+    "Generate Map": {
+        errorCondition: isNotAtLeastOne,
+        errorMessage: "Please select at least one parcel.",
+    },
+};
 interface ActionsInputComponentProps {
     actionName: ActionName;
     selectedParcels: ParcelsTableRow[];
@@ -234,6 +240,42 @@ const Actions: React.FC<Props> = ({
         };
     };
 
+    const mapsLinkForParcels = (): string => {
+        const mapsLinkList = ["https://www.google.com/maps/dir/"];
+        selectedParcels.map((parcel) => {
+            mapsLinkList.push(parcel.addressPostcode + "/");
+        });
+        mapsLinkList.push("/");
+        const mapsLinkString = mapsLinkList.join("");
+        return mapsLinkString;
+    };
+
+    const openInNewTab = (url: string): void => {
+        const newWindow = window.open(url, "_blank", "noopener, noreferrer");
+        if (newWindow) {
+            newWindow.opener = null;
+        }
+    };
+
+    const onMapsClick = (
+        errorCondition: (value: number) => boolean,
+        errorMessage: string
+    ): (() => void) => {
+        return () => {
+            if (errorCondition(selectedParcels.length)) {
+                setActionAnchorElement(null);
+                setModalError(errorMessage);
+            } else {
+                const mapsLink = mapsLinkForParcels();
+                openInNewTab(mapsLink);
+            }
+        };
+    };
+
+    useEffect(() => {
+        console.log(mapsLinkForParcels());
+    }, [selectedParcels]);
+
     return (
         <>
             {Object.entries(availableActions).map(([key, value]) => {
@@ -295,6 +337,14 @@ const Actions: React.FC<Props> = ({
                                 </MenuItem>
                             );
                         })}
+                        <MenuItem
+                            onClick={onMapsClick(
+                                generateMapAction["Generate Map"].errorCondition,
+                                generateMapAction["Generate Map"].errorMessage
+                            )}
+                        >
+                            Generate Map
+                        </MenuItem>
                     </MenuList>
                 </Menu>
             )}

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -47,7 +47,6 @@ type AvailableActionsType = {
         errorCondition: (value: number) => boolean;
         errorMessage: string;
         actionType: ActionType;
-        shouldOpenModal: boolean;
     };
 };
 
@@ -57,21 +56,18 @@ const availableActions: AvailableActionsType = {
         errorCondition: doesNotEqualOne,
         errorMessage: "Please select exactly one parcel.",
         actionType: "pdfDownload",
-        shouldOpenModal: true,
     },
     "Download Shopping Lists": {
         showSelectedParcelsInModal: true,
         errorCondition: isNotAtLeastOne,
         errorMessage: "Please select at least one parcel.",
         actionType: "pdfDownload",
-        shouldOpenModal: true,
     },
     "Download Driver Overview": {
         showSelectedParcelsInModal: true,
         errorCondition: isNotAtLeastOne,
         errorMessage: "Please select at least one parcel.",
         actionType: "pdfDownload",
-        shouldOpenModal: true,
     },
     "Download Day Overview": {
         showSelectedParcelsInModal: false,
@@ -79,21 +75,18 @@ const availableActions: AvailableActionsType = {
         errorMessage:
             "The day overview will show the parcels for a particular date and location. It will show not the currently selected parcel. Please unselect the parcels.",
         actionType: "pdfDownload",
-        shouldOpenModal: true,
     },
     "Delete Parcel Request": {
         showSelectedParcelsInModal: true,
         errorCondition: isNotAtLeastOne,
         errorMessage: "Please select at least one parcel.",
         actionType: "deleteParcel",
-        shouldOpenModal: true,
     },
     "Generate Map": {
         showSelectedParcelsInModal: false,
         errorCondition: isNotAtLeastOne,
         errorMessage: "Please select at least one parcel.",
         actionType: "generateMap",
-        shouldOpenModal: false,
     },
 };
 
@@ -234,21 +227,26 @@ const Actions: React.FC<Props> = ({
     const onMenuItemClick = (
         key: ActionName,
         errorCondition: (value: number) => boolean,
-        errorMessage: string,
-        shouldOpenModal: boolean
+        errorMessage: string
     ): (() => void) => {
         return () => {
             if (errorCondition(selectedParcels.length)) {
                 setActionAnchorElement(null);
                 setModalError(errorMessage);
             } else {
-                if (!shouldOpenModal) {
-                    const mapsLink = mapsLinkForSelectedParcels();
-                    openInNewTab(mapsLink);
-                } else {
-                    setModalToDisplay(key);
-                    setActionAnchorElement(null);
-                    setModalError(null);
+                switch (key) {
+                    case "Download Shipping Labels":
+                    case "Download Shopping Lists":
+                    case "Download Driver Overview":
+                    case "Download Day Overview":
+                    case "Delete Parcel Request":
+                        setModalToDisplay(key);
+                        setActionAnchorElement(null);
+                        setModalError(null);
+                        break;
+                    case "Generate Map":
+                        openInNewTab(mapsLinkForSelectedParcels());
+                        break;
                 }
             }
         };
@@ -320,8 +318,7 @@ const Actions: React.FC<Props> = ({
                                     onClick={onMenuItemClick(
                                         key as ActionName,
                                         value.errorCondition,
-                                        value.errorMessage,
-                                        value.shouldOpenModal
+                                        value.errorMessage
                                     )}
                                 >
                                     {key}

--- a/src/app/parcels/ActionBar/ActionsModal.tsx
+++ b/src/app/parcels/ActionBar/ActionsModal.tsx
@@ -14,7 +14,7 @@ import { DatabaseError } from "@/app/errorClasses";
 import { statusType } from "./Statuses";
 import SelectedParcelsOverview from "./SelectedParcelsOverview";
 
-export type ActionType = "pdfDownload" | "deleteParcel";
+export type ActionType = "pdfDownload" | "deleteParcel" | "generateMap";
 
 interface ActionsModalProps extends React.ComponentProps<typeof Modal> {
     selectedParcels: ParcelsTableRow[];


### PR DESCRIPTION
## What's changed
- Add generate map under actions on parcels page
- Opens google maps in new tab with the selected parcels postcode in a circular pin
- Shows error message if no parcels are selected

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/70527083-df27-4feb-b858-3f0380ae8574) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/7c189277-b839-4a96-9096-6ee41f32ab9e) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA 
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
  - Will also be automatically checked on pull request
- [x] Make sure you've tested via `npm run test`
  - Will also be automatically checked on pull request
