### PR TITLE
VFB-74: Delete parcel action FIX

### DIFF
--- a/src/app/parcels/ActionBar/ActionsModal.tsx
+++ b/src/app/parcels/ActionBar/ActionsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import Modal from "@/components/Modal/Modal";
 import { Dayjs } from "dayjs";
@@ -177,7 +177,7 @@ const ActionsModal: React.FC<ActionsModalProps> = (props) => {
         }
     }, [loading, loadPdf]);
 
-    const numberOfParcelsToDelete = useMemo<number>(() => props.selectedParcels.length, []);
+    const [numberOfParcelsToDelete] = useState<number>(props.selectedParcels.length);
 
     return (
         <Modal {...props}>

--- a/src/app/parcels/ActionBar/ActionsModal.tsx
+++ b/src/app/parcels/ActionBar/ActionsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import Modal from "@/components/Modal/Modal";
 import { Dayjs } from "dayjs";
@@ -177,6 +177,8 @@ const ActionsModal: React.FC<ActionsModalProps> = (props) => {
         }
     }, [loading, loadPdf]);
 
+    const numberOfParcelsToDelete = useMemo<number>(() => props.selectedParcels.length, []);
+
     return (
         <Modal {...props}>
             <ModalInner>
@@ -188,7 +190,7 @@ const ActionsModal: React.FC<ActionsModalProps> = (props) => {
                             <Heading> The PDF is ready to be downloaded. </Heading>
                         ) : (
                             <Heading>
-                                {props.selectedParcels.length === 1 ? "Parcel" : "Parcels"} deleted
+                                {numberOfParcelsToDelete === 1 ? "Parcel" : "Parcels"} deleted
                             </Heading>
                         )}
 
@@ -199,7 +201,7 @@ const ActionsModal: React.FC<ActionsModalProps> = (props) => {
                         {props.actionType === "deleteParcel" && (
                             <Heading>
                                 Are you sure you want to delete the selected parcel{" "}
-                                {props.selectedParcels.length === 1 ? "request" : "requests"}?
+                                {numberOfParcelsToDelete === 1 ? "request" : "requests"}?
                             </Heading>
                         )}
                         {props.showSelectedParcels && (


### PR DESCRIPTION
## What's changed
In the delete parcel modal, the confirmation displayed "Parcels deleted" indiscriminate of how many parcels were deleted. Now it displays "Parcel deleted" if one was deleted and "Parcels deleted" if more than one was deleted.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/1616be69-63ed-4590-bdb9-9a185d56d93b) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/26659025-80f4-4ae6-af19-61e027d47e17) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA 
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
  - Will also be automatically checked on pull request
- [x] Make sure you've tested via `npm run test`
  - Will also be automatically checked on pull request
