### PR TITLE
VFB-145: Open client modal after editing client

### DIFF
--- a/src/app/clients/form/submitFormHelpers.ts
+++ b/src/app/clients/form/submitFormHelpers.ts
@@ -263,7 +263,7 @@ export const submitEditClientForm: SubmitFormHelper = async (
     const ids = await updateClient(clientRecord, primaryKey!);
     try {
         await updateFamily(fields.adults, fields.children, ids.family_id);
-        router.push(`/parcels/add/${ids.primary_key}`);
+        router.push(`/clients?clientId=${primaryKey}`);
     } catch (error) {
         await revertClientUpdate(clientBeforeUpdate, primaryKey!);
         throw new DatabaseError("update", "client data");


### PR DESCRIPTION
## What's changed
After pressing the submit button in the edit client modal, we now navigate to the respective updated client details modal, instead of navigating to the add parcel modal.

## Screenshots / Videos
After clicking "submit" in the edit client modal...
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/cf587015-5bdf-49bb-88ac-6c7800901955) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/6c98ca1e-5f66-49bd-a613-5d006635ef20) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA 
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database... nope
