### PR TITLE
#154: Duplicate collection centre error message

### DIFF
--- a/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
+++ b/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
@@ -34,7 +34,6 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
     const [fields, setFields] = useState(initialFields);
     const [formErrors, setFormErrors] = useState(initialFormErrors);
 
-    const [submitError, setSubmitError] = useState(Errors.none);
     const [submitErrorMessage, setSubmitErrorMessage] = useState("");
     const [submitDisabled, setSubmitDisabled] = useState(false);
 
@@ -47,7 +46,6 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
         setSubmitDisabled(true);
 
         if (checkErrorOnSubmit(formErrors, setFormErrors)) {
-            setSubmitError(Errors.submit);
             setSubmitDisabled(false);
             return;
         }
@@ -55,13 +53,17 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
         const { error } = await supabase.from("collection_centres").insert(fields);
 
         if (error) {
-            setSubmitError(Errors.external);
-            setSubmitErrorMessage(error.message);
+            if (error.code === "23505") {
+                setSubmitErrorMessage(
+                    "A Collection Centre with this name/abbreviation has already been added. Please choose a different name/abbreviation"
+                );
+            } else {
+                setSubmitErrorMessage(`${error.message}\n${Errors.external}`);
+            }
             setSubmitDisabled(false);
             return;
         }
 
-        setSubmitError(Errors.none);
         setSubmitErrorMessage("");
         setSubmitDisabled(false);
         setRefreshRequired(true);
@@ -93,7 +95,7 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
                     </Button>
                 )}
 
-                <FormErrorText>{submitErrorMessage + submitError}</FormErrorText>
+                <FormErrorText>{submitErrorMessage}</FormErrorText>
             </StyledForm>
         </CenterComponent>
     );


### PR DESCRIPTION
## What's changed
When adding a collection centre with a name and/or acronym duplicating those that already exist, 

## Screenshots / Videos
| Before     | After      |
|------------|------------|
|![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/134699c1-17bc-4fcc-8e23-83634ac62db2)| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/1736055d-c4b6-44e7-bb3d-8b78836cca8b)|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA 
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database... nope