### PR TITLE
#156: Reduce width of shipping label to 150mm from 200mm

### DIFF
--- a/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
+++ b/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
@@ -23,7 +23,7 @@ const mmToPixels = (mm: number): number => {
     return mm * pixelsPerMmAt72Dpi;
 };
 
-const labelSizePixels = { width: mmToPixels(200), height: mmToPixels(62) };
+const labelSizePixels = { width: mmToPixels(150), height: mmToPixels(62) };
 
 const styles = StyleSheet.create({
     page: {
@@ -109,7 +109,7 @@ const LabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) => {
                             <br />
                         </Text>
                     </View>
-                    <View>
+                    <View style={styles.middleCol}>
                         <Text style={styles.headingText}>Delivery Instructions:</Text>
                         <Text>{data.delivery_instructions}</Text>
                     </View>


### PR DESCRIPTION
## What's changed
Reduce width of shipping label to 150mm from 200mm, and made delivery instructions text wrap on to the next row(s) if needed, so it doesn't get cut off.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/1465fcff-02de-4c4e-9fe0-f9497ef28129) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/7cafa42b-6d3b-4a17-a3a2-c56377ebb564) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA 
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database... nope
