### PR TITLE
#158: Default date to today in driver overview pdf input

### DIFF
--- a/src/app/parcels/ActionBar/ActionsModal.tsx
+++ b/src/app/parcels/ActionBar/ActionsModal.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import Modal from "@/components/Modal/Modal";
-import { Dayjs } from "dayjs";
+import dayjs, { Dayjs } from "dayjs";
 import { ParcelsTableRow } from "@/app/parcels/getParcelsTableData";
 import { Button, SelectChangeEvent } from "@mui/material";
 import FreeFormTextInput from "@/components/DataInput/FreeFormTextInput";
@@ -112,7 +112,7 @@ export const DriverOverviewInput: React.FC<DriverOverviewInputProps> = ({
         <>
             <Heading>Delivery Information</Heading>
             <FreeFormTextInput onChange={onDriverNameChange} label="Driver's Name" />
-            <DatePicker onChange={onDateChange} disablePast />
+            <DatePicker defaultValue={dayjs()} onChange={onDateChange} disablePast />
         </>
     );
 };


### PR DESCRIPTION
## What's changed
In the driver overview pdf modal, the date is now defaulted to today. Previously, there was no default value.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/af5acd6c-2102-4b45-b712-36c2d8236fb5) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/be806e75-9000-49ca-b465-c335147b24ec) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA 
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database... nope
