### PR TITLE
155:Logout-confirmation-modal

### DIFF
--- a/cypress/e2e/auth.cy.ts
+++ b/cypress/e2e/auth.cy.ts
@@ -40,6 +40,7 @@ describe("Authentication tests", () => {
         cy.visit("/parcels");
         cy.url().should("include", "/parcels");
         cy.get("button[aria-label='Sign Out Button']").click();
+        cy.get("button[aria-label='Confirm Sign Out Button']").click();
 
         cy.url().should("include", "/login");
     });

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@
 
 import React, { ReactNode } from "react";
 import styled from "styled-components";
-import { Dialog } from "@mui/material";
+import { Breakpoint, Dialog } from "@mui/material";
 import { faClose } from "@fortawesome/free-solid-svg-icons";
 import Icon from "@/components/Icons/Icon";
 
@@ -87,6 +87,7 @@ export interface ModalProps {
     headerId: string;
     className?: string;
     footer?: ReactNode;
+    maxWidth?: Breakpoint;
 }
 
 const StyledIcon = styled(Icon)`
@@ -102,7 +103,7 @@ const Modal: React.FC<ModalProps> = (props) => {
             aria-labelledby={props.headerId}
             className={props.className}
             fullWidth
-            maxWidth="md"
+            maxWidth={props.maxWidth ? props.maxWidth : "md"}
         >
             <Header id={props.headerId} className="header">
                 {props.header}

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -229,7 +229,7 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
                             onClick={handleLogOutConfirm}
                             variant="contained"
                         >
-                            LogOut
+                            Log Out
                         </Button>
                         <Button
                             aria-label="Cancel Sign Out"

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -102,6 +102,13 @@ const SignOutButtonContainer = styled(NavElementContainer)`
     gap: 1rem;
 `;
 
+const CenteredDiv = styled.div`
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    margin: 2rem 4rem 1rem 4rem;
+`;
+
 const LoginDependent: React.FC<Props> = (props) => {
     const pathname = usePathname();
     if (pathname === "/login") {
@@ -248,10 +255,4 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
     );
 };
 
-const CenteredDiv = styled.div`
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-    margin: 2rem 4rem 1rem 4rem;
-`;
 export default NavigationBar;

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -220,7 +220,7 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
                         setLogOutModalOpen(false);
                     }}
                     headerId="expandedParcelDetailsModal"
-                    maxWidth="sm"
+                    maxWidth="xs"
                 >
                     <CenteredDiv>
                         <Button

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import AppBar from "@mui/material/AppBar";
 import MenuIcon from "@mui/icons-material/Menu";
 import SwipeableDrawer from "@mui/material/SwipeableDrawer";
@@ -12,6 +12,10 @@ import SignOutButton from "@/components/NavigationBar/SignOutButton";
 import NavBarButton from "@/components/Buttons/NavBarButton";
 import { usePathname } from "next/navigation";
 import { RoleUpdateContext, roleCanAccessPage } from "@/app/roles";
+import Modal from "@/components/Modal/Modal";
+import LogoutIcon from "@mui/icons-material/Logout";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { DatabaseAutoType } from "@/databaseUtils";
 
 export const NavBarHeight = "4rem";
 
@@ -130,7 +134,9 @@ const pages = [
 ];
 
 const NavigationBar: React.FC<Props> = ({ children }) => {
-    const [drawer, setDrawer] = React.useState(false);
+    const [drawer, setDrawer] = useState(false);
+    const [logOutModalOpen, setLogOutModalOpen] = useState(false);
+    const supabase = createClientComponentClient<DatabaseAutoType>();
 
     const openDrawer = (): void => {
         setDrawer(true);
@@ -138,6 +144,15 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
 
     const closeDrawer = (): void => {
         setDrawer(false);
+    };
+
+    const handleLogOutClick = (): void => {
+        setLogOutModalOpen(true);
+    };
+
+    const handleLogOutConfirm = async (): Promise<void> => {
+        setLogOutModalOpen(false);
+        await supabase.auth.signOut();
     };
 
     return (
@@ -187,13 +202,56 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
                     <SignOutButtonContainer>
                         <LightDarkSlider />
                         <LoginDependent>
-                            <SignOutButton />
+                            <SignOutButton onClick={handleLogOutClick} />
                         </LoginDependent>
                     </SignOutButtonContainer>
                 </AppBarInner>
             </AppBar>
+            {logOutModalOpen && (
+                <Modal
+                    header={
+                        <>
+                            <LogoutIcon />
+                            Would you like to log out?
+                        </>
+                    }
+                    isOpen={logOutModalOpen}
+                    onClose={() => {
+                        setLogOutModalOpen(false);
+                    }}
+                    headerId="expandedParcelDetailsModal"
+                    maxWidth="sm"
+                >
+                    <CenteredDiv>
+                        <Button
+                            color="primary"
+                            aria-label="Confirm Sign Out Button"
+                            onClick={handleLogOutConfirm}
+                            variant="contained"
+                        >
+                            LogOut
+                        </Button>
+                        <Button
+                            aria-label="Cancel Sign Out"
+                            onClick={() => {
+                                setLogOutModalOpen(false);
+                            }}
+                            variant="outlined"
+                        >
+                            Cancel
+                        </Button>
+                    </CenteredDiv>
+                </Modal>
+            )}
             {children}
         </>
     );
 };
+
+const CenteredDiv = styled.div`
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    margin: 2rem 4rem 1rem 4rem;
+`;
 export default NavigationBar;

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -135,7 +135,7 @@ const pages = [
 
 const NavigationBar: React.FC<Props> = ({ children }) => {
     const [drawer, setDrawer] = useState(false);
-    const [logOutModalOpen, setLogOutModalOpen] = useState(false);
+    const [islogOutModalOpen, setIslogOutModalOpen] = useState(false);
     const supabase = createClientComponentClient<DatabaseAutoType>();
 
     const openDrawer = (): void => {
@@ -147,11 +147,11 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
     };
 
     const handleLogOutClick = (): void => {
-        setLogOutModalOpen(true);
+        setIslogOutModalOpen(true);
     };
 
     const handleLogOutConfirm = async (): Promise<void> => {
-        setLogOutModalOpen(false);
+        setIslogOutModalOpen(false);
         await supabase.auth.signOut();
     };
 
@@ -207,7 +207,7 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
                     </SignOutButtonContainer>
                 </AppBarInner>
             </AppBar>
-            {logOutModalOpen && (
+            {islogOutModalOpen && (
                 <Modal
                     header={
                         <>
@@ -215,9 +215,9 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
                             Would you like to log out?
                         </>
                     }
-                    isOpen={logOutModalOpen}
+                    isOpen={islogOutModalOpen}
                     onClose={() => {
-                        setLogOutModalOpen(false);
+                        setIslogOutModalOpen(false);
                     }}
                     headerId="expandedParcelDetailsModal"
                     maxWidth="xs"
@@ -234,7 +234,7 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
                         <Button
                             aria-label="Cancel Sign Out"
                             onClick={() => {
-                                setLogOutModalOpen(false);
+                                setIslogOutModalOpen(false);
                             }}
                             variant="outlined"
                         >

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -224,7 +224,7 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
                 >
                     <CenteredDiv>
                         <Button
-                            color="primary"
+                            color="error"
                             aria-label="Confirm Sign Out Button"
                             onClick={handleLogOutConfirm}
                             variant="contained"

--- a/src/components/NavigationBar/SignOutButton.tsx
+++ b/src/components/NavigationBar/SignOutButton.tsx
@@ -7,6 +7,7 @@ import IconButton from "@mui/material/IconButton/IconButton";
 interface Props {
     onClick: () => void;
 }
+
 const SignOutButton: React.FC<Props> = (props: Props) => {
     return (
         <IconButton aria-label="Sign Out Button" onClick={props.onClick}>

--- a/src/components/NavigationBar/SignOutButton.tsx
+++ b/src/components/NavigationBar/SignOutButton.tsx
@@ -2,20 +2,14 @@
 
 import React from "react";
 import LogoutIcon from "@mui/icons-material/Logout";
-import { DatabaseAutoType } from "@/databaseUtils";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import IconButton from "@mui/material/IconButton/IconButton";
 
-const SignOutButton: React.FC<{}> = () => {
-    const supabase = createClientComponentClient<DatabaseAutoType>();
-
+interface Props {
+    onClick: () => void;
+}
+const SignOutButton: React.FC<Props> = (props: Props) => {
     return (
-        <IconButton
-            aria-label="Sign Out Button"
-            onClick={async () => {
-                await supabase.auth.signOut();
-            }}
-        >
+        <IconButton aria-label="Sign Out Button" onClick={props.onClick}>
             <LogoutIcon />
         </IconButton>
     );


### PR DESCRIPTION
## What's changed
Added a confirmation modal when logout icon is clicked.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/49fda7d0-eaa5-49eb-900f-d030ab616bea) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/6d9d1e53-43ae-44b9-973e-dc3123a04ad9) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA 
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database... No changes to database
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
