### PR TITLE
VFB-29: FIX request pagination

### DIFF
--- a/src/app/clients/ClientsPage.tsx
+++ b/src/app/clients/ClientsPage.tsx
@@ -84,7 +84,7 @@ const ClientsPage: React.FC<{}> = () => {
     const [filteredClientCount, setFilteredClientCount] = useState<number>(0);
     const [sortState, setSortState] = useState<SortState<ClientsTableRow>>({ sortEnabled: false });
     const [primaryFilters, setPrimaryFilters] = useState<Filter<ClientsTableRow, any>[]>(filters);
-    const abortController = useRef<AbortController>();
+    const clientTableFetchAbortController = useRef<AbortController | null>(null);
 
     const [perPage, setPerPage] = useState(10);
     const [currentPage, setCurrentPage] = useState(1);
@@ -94,15 +94,15 @@ const ClientsPage: React.FC<{}> = () => {
     useEffect(() => {
         (async () => {
             setIsLoading(true);
-            if (abortController.current) {
-                abortController.current.abort("stale request");
+            if (clientTableFetchAbortController.current) {
+                clientTableFetchAbortController.current.abort("stale request");
             }
-            abortController.current = new AbortController();
-            if (abortController.current) {
+            clientTableFetchAbortController.current = new AbortController();
+            if (clientTableFetchAbortController.current) {
                 const filteredClientCount = await getClientsCount(
                     supabase,
                     primaryFilters,
-                    abortController.current.signal
+                    clientTableFetchAbortController.current.signal
                 );
                 const fetchedData = await getClientsData(
                     supabase,
@@ -110,9 +110,9 @@ const ClientsPage: React.FC<{}> = () => {
                     endPoint,
                     primaryFilters,
                     sortState,
-                    abortController.current.signal
+                    clientTableFetchAbortController.current.signal
                 );
-                abortController.current = undefined;
+                clientTableFetchAbortController.current = null;
                 !filteredClientCount.abortSignalResponse.aborted &&
                     setFilteredClientCount(filteredClientCount.count);
                 !fetchedData.abortSignalResponse.aborted && setClientsDataPortion(fetchedData.data);
@@ -125,15 +125,15 @@ const ClientsPage: React.FC<{}> = () => {
     useEffect(() => {
         const loadCountAndData = async (): Promise<void> => {
             setIsLoading(true);
-            if (abortController.current) {
-                abortController.current.abort("stale request");
+            if (clientTableFetchAbortController.current) {
+                clientTableFetchAbortController.current.abort("stale request");
             }
-            abortController.current = new AbortController();
-            if (abortController.current) {
+            clientTableFetchAbortController.current = new AbortController();
+            if (clientTableFetchAbortController.current) {
                 const filteredParcelCount = await getClientsCount(
                     supabase,
                     primaryFilters,
-                    abortController.current.signal
+                    clientTableFetchAbortController.current.signal
                 );
                 const fetchedData = await getClientsData(
                     supabase,
@@ -141,9 +141,9 @@ const ClientsPage: React.FC<{}> = () => {
                     endPoint,
                     primaryFilters,
                     sortState,
-                    abortController.current.signal
+                    clientTableFetchAbortController.current.signal
                 );
-                abortController.current = undefined;
+                clientTableFetchAbortController.current = null;
                 !filteredParcelCount.abortSignalResponse.aborted &&
                     setFilteredClientCount(filteredParcelCount.count);
                 !fetchedData.abortSignalResponse.aborted && setClientsDataPortion(fetchedData.data);

--- a/src/app/clients/ClientsPage.tsx
+++ b/src/app/clients/ClientsPage.tsx
@@ -92,61 +92,61 @@ const ClientsPage: React.FC<{}> = () => {
     const endPoint = currentPage * perPage - 1;
 
     useEffect(() => {
-        (async () => {
-            setIsLoading(true);
-            if (clientTableFetchAbortController.current) {
-                clientTableFetchAbortController.current.abort("stale request");
-            }
-            clientTableFetchAbortController.current = new AbortController();
-            if (clientTableFetchAbortController.current) {
-                const filteredClientCount = await getClientsCount(
-                    supabase,
-                    primaryFilters,
-                    clientTableFetchAbortController.current.signal
-                );
-                const fetchedData = await getClientsData(
-                    supabase,
-                    startPoint,
-                    endPoint,
-                    primaryFilters,
-                    sortState,
-                    clientTableFetchAbortController.current.signal
-                );
-                clientTableFetchAbortController.current = null;
-                !filteredClientCount.abortSignalResponse.aborted &&
-                    setFilteredClientCount(filteredClientCount.count);
-                !fetchedData.abortSignalResponse.aborted && setClientsDataPortion(fetchedData.data);
-            }
-            setIsLoading(false);
-            setIsLoadingForFirstTime(false);
-        })();
+        setIsLoading(true);
+        if (clientTableFetchAbortController.current) {
+            clientTableFetchAbortController.current.abort("stale request");
+        }
+        clientTableFetchAbortController.current = new AbortController();
+        if (clientTableFetchAbortController.current) {
+            getClientsCount(
+                supabase,
+                primaryFilters,
+                clientTableFetchAbortController.current.signal
+            )
+                .then((count) => setFilteredClientCount(count))
+                .catch();
+            getClientsData(
+                supabase,
+                startPoint,
+                endPoint,
+                primaryFilters,
+                sortState,
+                clientTableFetchAbortController.current.signal
+            )
+                .then((data) => setClientsDataPortion(data))
+                .catch();
+            clientTableFetchAbortController.current = null;
+        }
+        setIsLoading(false);
+        setIsLoadingForFirstTime(false);
     }, [startPoint, endPoint, primaryFilters, sortState]);
 
     useEffect(() => {
-        const loadCountAndData = async (): Promise<void> => {
+        const loadCountAndData = (): void => {
             setIsLoading(true);
             if (clientTableFetchAbortController.current) {
                 clientTableFetchAbortController.current.abort("stale request");
             }
             clientTableFetchAbortController.current = new AbortController();
             if (clientTableFetchAbortController.current) {
-                const filteredParcelCount = await getClientsCount(
+                getClientsCount(
                     supabase,
                     primaryFilters,
                     clientTableFetchAbortController.current.signal
-                );
-                const fetchedData = await getClientsData(
+                )
+                    .then((count) => setFilteredClientCount(count))
+                    .catch();
+                getClientsData(
                     supabase,
                     startPoint,
                     endPoint,
                     primaryFilters,
                     sortState,
                     clientTableFetchAbortController.current.signal
-                );
+                )
+                    .then((data) => setClientsDataPortion(data))
+                    .catch();
                 clientTableFetchAbortController.current = null;
-                !filteredParcelCount.abortSignalResponse.aborted &&
-                    setFilteredClientCount(filteredParcelCount.count);
-                !fetchedData.abortSignalResponse.aborted && setClientsDataPortion(fetchedData.data);
             }
             setIsLoading(false);
             setIsLoadingForFirstTime(false);

--- a/src/app/clients/ClientsPage.tsx
+++ b/src/app/clients/ClientsPage.tsx
@@ -19,7 +19,7 @@ import { Filter, PaginationType } from "@/components/Tables/Filters";
 import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 import { Database } from "@/databaseTypesFile";
 import { CircularProgress } from "@mui/material";
-import { RequestParams, areRequestsIdentical } from "../parcels/fetchParcelTableData";
+import { RequestParams, areParamsIdentical } from "../parcels/fetchParcelTableData";
 
 export interface ClientsTableRow {
     clientId: string;
@@ -114,7 +114,7 @@ const ClientsPage: React.FC<{}> = () => {
                 startPoint: startPoint,
                 endPoint: endPoint,
             };
-            if (areRequestsIdentical(requestParams, initialRequestParams)) {
+            if (areParamsIdentical(requestParams, initialRequestParams)) {
                 setClientsDataPortion(fetchedData);
                 setFilteredClientCount(filteredClientCount);
             }

--- a/src/app/errorClasses.ts
+++ b/src/app/errorClasses.ts
@@ -10,6 +10,17 @@ export class DatabaseError extends Error {
     }
 }
 
+export class AbortError extends Error {
+    constructor(errorCategory: DatabaseOperation, faultyArea = "", logId: string) {
+        super(
+            `The following request was aborted: the ${errorCategory} operation` +
+                (faultyArea !== "" ? ` (${faultyArea})` : "") +
+                `Log ID: ${logId}`
+        );
+        this.name = "AbortError";
+    }
+}
+
 type DatabaseOperation = "fetch" | "insert" | "update" | "delete";
 
 export class EdgeFunctionError extends Error {

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -367,7 +367,7 @@ const ParcelsPage: React.FC<{}> = () => {
     const [areFiltersLoadingForFirstTime, setAreFiltersLoadingForFirstTime] =
         useState<boolean>(true);
 
-    const abortController = useRef<AbortController>();
+    const parcelsTableFetchAbortController = useRef<AbortController | null>(null);
 
     useEffect(() => {
         if (parcelId) {
@@ -441,25 +441,25 @@ const ParcelsPage: React.FC<{}> = () => {
             const allFilters = [...primaryFilters.slice(), ...additionalFilters.slice()];
             (async () => {
                 setIsLoading(true);
-                if (abortController.current) {
-                    abortController.current.abort("stale request");
+                if (parcelsTableFetchAbortController.current) {
+                    parcelsTableFetchAbortController.current.abort("stale request");
                 }
-                abortController.current = new AbortController();
-                if (abortController.current) {
+                parcelsTableFetchAbortController.current = new AbortController();
+                if (parcelsTableFetchAbortController.current) {
                     const filteredParcelCount = await getParcelsCount(
                         supabase,
                         allFilters,
-                        abortController.current.signal
+                        parcelsTableFetchAbortController.current.signal
                     );
                     const fetchedData = await getParcelsData(
                         supabase,
                         allFilters,
                         sortState,
-                        abortController.current.signal,
+                        parcelsTableFetchAbortController.current.signal,
                         startPoint,
                         endPoint
                     );
-                    abortController.current = undefined;
+                    parcelsTableFetchAbortController.current = null;
                     !filteredParcelCount.abortSignalResponse.aborted &&
                         setFilteredParcelCount(filteredParcelCount.count);
                     !fetchedData.abortSignalResponse.aborted &&
@@ -489,25 +489,25 @@ const ParcelsPage: React.FC<{}> = () => {
 
                 setIsLoading(true);
                 fetchParcelsTimer.current = setTimeout(async () => {
-                    if (abortController.current) {
-                        abortController.current.abort("stale request");
+                    if (parcelsTableFetchAbortController.current) {
+                        parcelsTableFetchAbortController.current.abort("stale request");
                     }
-                    abortController.current = new AbortController();
-                    if (abortController.current) {
+                    parcelsTableFetchAbortController.current = new AbortController();
+                    if (parcelsTableFetchAbortController.current) {
                         const filteredParcelCount = await getParcelsCount(
                             supabase,
                             allFilters,
-                            abortController.current.signal
+                            parcelsTableFetchAbortController.current.signal
                         );
                         const fetchedData = await getParcelsData(
                             supabase,
                             allFilters,
                             sortState,
-                            abortController.current.signal,
+                            parcelsTableFetchAbortController.current.signal,
                             startPoint,
                             endPoint
                         );
-                        abortController.current = undefined;
+                        parcelsTableFetchAbortController.current = null;
                         !filteredParcelCount.abortSignalResponse.aborted &&
                             setFilteredParcelCount(filteredParcelCount.count);
                         !fetchedData.abortSignalResponse.aborted &&

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -367,7 +367,7 @@ const ParcelsPage: React.FC<{}> = () => {
     const [areFiltersLoadingForFirstTime, setAreFiltersLoadingForFirstTime] =
         useState<boolean>(true);
 
-    const abortController = useRef<AbortController | null>();
+    const abortController = useRef<AbortController>();
 
     useEffect(() => {
         if (parcelId) {
@@ -436,50 +436,6 @@ const ParcelsPage: React.FC<{}> = () => {
         })();
     }, []);
 
-    // useEffect(() => {
-    //     if (!areFiltersLoadingForFirstTime) {
-    //         const allFilters = [...primaryFilters.slice(), ...additionalFilters.slice()];
-    //         const requestParams: RequestParams<ParcelsTableRow> = {
-    //             allFilters: { ...allFilters },
-    //             sortState: { ...sortState },
-    //             startPoint: startPoint,
-    //             endPoint: endPoint,
-    //         };
-    //         console.log("request params ", requestParams.allFilters[0].state);
-    //         (async () => {
-    //             setIsLoading(true);
-    //             const filteredParcelCount = await getParcelsCount(supabase, allFilters);
-    //             const fetchedData = await getParcelsData(
-    //                 supabase,
-    //                 allFilters,
-    //                 sortState,
-    //                 startPoint,
-    //                 endPoint
-    //             );
-    //             console.log("primary filters 0 ", primaryFilters[0].state);
-    //             const currentStateValues: RequestParams<ParcelsTableRow> = {
-    //                 allFilters: [...primaryFilters.slice(), ...additionalFilters.slice()],
-    //                 sortState: { ...sortState },
-    //                 startPoint: startPoint,
-    //                 endPoint: endPoint,
-    //             };
-    //             console.log("current state values ", currentStateValues.allFilters[0].state);
-    //             if (areParamsIdentical(currentStateValues, requestParams)) {
-    //                 setFilteredParcelCount(filteredParcelCount);
-    //                 setParcelsDataPortion(fetchedData);
-    //             }
-    //             setIsLoading(false);
-    //         })();
-    //     }
-    // }, [
-    //     startPoint,
-    //     endPoint,
-    //     primaryFilters,
-    //     additionalFilters,
-    //     sortState,
-    //     areFiltersLoadingForFirstTime,
-    // ]);
-
     useEffect(() => {
         if (!areFiltersLoadingForFirstTime) {
             const allFilters = [...primaryFilters.slice(), ...additionalFilters.slice()];
@@ -503,7 +459,7 @@ const ParcelsPage: React.FC<{}> = () => {
                         startPoint,
                         endPoint
                     );
-                    abortController.current = null;
+                    abortController.current = undefined;
                     !filteredParcelCount.abortSignalResponse.aborted &&
                         setFilteredParcelCount(filteredParcelCount.count);
                     !fetchedData.abortSignalResponse.aborted &&
@@ -551,7 +507,7 @@ const ParcelsPage: React.FC<{}> = () => {
                             startPoint,
                             endPoint
                         );
-                        abortController.current = null;
+                        abortController.current = undefined;
                         !filteredParcelCount.abortSignalResponse.aborted &&
                             setFilteredParcelCount(filteredParcelCount.count);
                         !fetchedData.abortSignalResponse.aborted &&

--- a/src/app/parcels/fetchParcelTableData.ts
+++ b/src/app/parcels/fetchParcelTableData.ts
@@ -119,6 +119,7 @@ export const getParcelsCount = async (
     query = query.abortSignal(abortSignal);
 
     const { count, error } = await query;
+
     if (abortSignal.aborted) {
         return { count: 0, abortSignalResponse: abortSignal };
     }
@@ -212,11 +213,4 @@ export interface CollectionCentresOptions {
 }
 export interface StatusResponseRow {
     event_name: string;
-}
-
-export interface RequestParams<Data> {
-    allFilters: Filter<Data, any>[];
-    sortState: SortState<Data>;
-    startPoint: number;
-    endPoint: number;
 }

--- a/src/app/parcels/fetchParcelTableData.ts
+++ b/src/app/parcels/fetchParcelTableData.ts
@@ -178,9 +178,16 @@ export const areRequestsIdentical = <Data>(
     requestParamsA: RequestParams<Data>,
     requestParamsB: RequestParams<Data>
 ): boolean => {
-    const filtersSame = Array.from(requestParamsA.allFilters).every((filter, index) =>
-        filter.areStatesIdentical(filter.state, requestParamsB.allFilters[index].state)
-    );
+    // [...requestParamsA.allFilters].forEach((filter, index) => { console.log("p"); console.log(filter.key, filter.state, requestParamsB.allFilters[index].state, filter.areStatesIdentical(filter.state, requestParamsB.allFilters[index].state));}) 
+    // const filtersSame = [...requestParamsA.allFilters].every((filter, index) =>  (
+        // filter.areStatesIdentical(filter.state, requestParamsB.allFilters[index].state)));
+    let filtersSame = true;
+    console.log("requestParamsA.allfilters: ",requestParamsA.allFilters)
+    console.log("requestParamsA.allfilters.length: ",Object.keys(requestParamsA.allFilters).length);
+    for (var i = 0; i < Object.keys(requestParamsA.allFilters).length; i++){
+        console.log(requestParamsA.allFilters[i].key, requestParamsA.allFilters[i].state, requestParamsB.allFilters[i].state, requestParamsA.allFilters[i].areStatesIdentical(requestParamsA.allFilters[i].state, requestParamsB.allFilters[i].state));
+        if (filtersSame) {filtersSame = requestParamsA.allFilters[i].areStatesIdentical(requestParamsA.allFilters[i].state, requestParamsB.allFilters[i].state)}
+    }
     const sortStateSame =
         requestParamsA.sortState.sortEnabled === requestParamsB.sortState.sortEnabled &&
         requestParamsA.sortState.sortEnabled &&

--- a/src/components/Tables/Table.cy.tsx
+++ b/src/components/Tables/Table.cy.tsx
@@ -262,10 +262,6 @@ const Component: React.FC<TestTableProps> = ({
         ) {
             sortState.column.sortMethodConfig.method(sortState.sortDirection);
         }
-        sortState.sortEnabled &&
-            console.log(
-                `Data set by field ${sortState.column.sortField} in direction ${sortState.sortDirection}. Data is now:\n ${testDataPortion.map((row) => row.full_name)}`
-            );
     }, [sortState, testDataPortion]);
 
     return (


### PR DESCRIPTION
## What's changed
Fixed stale fetch logic, that was supposed to ensure that the most recently sent request is the one which the data is set to, no matter if another request returns sooner. It wasn't working, now it is. Both parcels and clients page.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... nope
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - NO 

