### PR TITLE
NONE: Fix accessibility issues in parcels page

### DIFF
--- a/src/components/DataInput/CheckboxGroupPopup.tsx
+++ b/src/components/DataInput/CheckboxGroupPopup.tsx
@@ -43,7 +43,7 @@ const CheckboxGroupPopup: React.FC<Props> = (props) => {
                 onClick={(event) => setPopoverAnchorElement(event.currentTarget)}
                 disabled={!props.labelsAndKeys.length}
                 type="button"
-                id="status-button"
+                id="checkbox-status-button"
                 endIcon={<ArrowDropDown />}
             >
                 {props.groupLabel}

--- a/src/components/DataInput/CheckboxGroupPopup.tsx
+++ b/src/components/DataInput/CheckboxGroupPopup.tsx
@@ -43,7 +43,6 @@ const CheckboxGroupPopup: React.FC<Props> = (props) => {
                 onClick={(event) => setPopoverAnchorElement(event.currentTarget)}
                 disabled={!props.labelsAndKeys.length}
                 type="button"
-                id="checkbox-status-button"
                 endIcon={<ArrowDropDown />}
             >
                 {props.groupLabel}

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -444,8 +444,12 @@ const Table = <Data,>({
                         sortServer={sortConfig.sortPossible}
                         onSort={handleSort}
                         progressComponent={
-                            <Centerer>
-                                <CircularProgress aria-label="table-progress-bar" />
+                            <Centerer role="rowgroup">
+                                <CircularProgress
+                                    role="row"
+                                    aria-label="table-progress-bar"
+                                    aria-busy={true}
+                                />
                             </Centerer>
                         }
                         progressPending={isLoading}


### PR DESCRIPTION
## What's changed
Fixed breaking accessibility test on parcels page:
- table didn't have the correct roles for its children when the loading symbol was displayed within the table
- there was a duplicate id "status-button"

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/f01ca48d-fc1e-4976-8a67-2bc46d79ecd1) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/8475d1f5-68b3-44fc-bd51-2f24f0d9c8f2) |

## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any. 
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`
