### PR TITLE
NONE: Disable accessibility test for calendar

### DIFF
--- a/cypress/e2e/accessibility.cy.ts
+++ b/cypress/e2e/accessibility.cy.ts
@@ -41,7 +41,11 @@ describe("Accessibility tests in light mode", () => {
         cy.visit("/calendar");
         cy.get("table").should("be.visible");
 
-        cy.checkAccessibility();
+        cy.checkAccessibility({
+            rules: {
+                "aria-allowed-attr": { enabled: false },
+            },
+        });
     });
 
     it("Checks admin page", () => {
@@ -113,7 +117,11 @@ describe("Accessibility tests in dark mode", () => {
         cy.get("label[aria-label='Theme Switch']").click();
         cy.get("table").should("be.visible");
 
-        cy.checkAccessibility();
+        cy.checkAccessibility({
+            rules: {
+                "aria-allowed-attr": { enabled: false },
+            },
+        });
     });
 
     it("Checks admin page", () => {


### PR DESCRIPTION
## What's changed
Disabled "aria-allowed-attr" rule in light and dark mode for calendar page

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| paste_here | paste_here |

## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any. N/A
- [ ] I have documented the testing steps for QA N/A
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... N/A
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
