### PR TITLE
VFB-165: Add label corresponding labelId to select for accessibility

### DIFF
--- a/src/app/admin/common/UserRoleDropdownInput.tsx
+++ b/src/app/admin/common/UserRoleDropdownInput.tsx
@@ -16,6 +16,7 @@ interface Props {
 const UserRoleDropdownInput: React.FC<Props> = (props) => {
     return (
         <DropdownListInput
+            selectLabel="user-role-select-label"
             listTitle="User Role"
             defaultValue={props.defaultValue}
             labelsAndValues={roleLabelsAndValues}

--- a/src/app/admin/common/UserRoleDropdownInput.tsx
+++ b/src/app/admin/common/UserRoleDropdownInput.tsx
@@ -16,7 +16,7 @@ interface Props {
 const UserRoleDropdownInput: React.FC<Props> = (props) => {
     return (
         <DropdownListInput
-            selectLabel="user-role-select-label"
+            selectLabelId="user-role-select-label"
             listTitle="User Role"
             defaultValue={props.defaultValue}
             labelsAndValues={roleLabelsAndValues}

--- a/src/app/clients/form/formSections/NumberChildrenCard.tsx
+++ b/src/app/clients/form/formSections/NumberChildrenCard.tsx
@@ -69,6 +69,7 @@ const NumberChildrenCard: React.FC<CardProps> = ({
                         <StyledCard key={child.primaryKey}>
                             <FormText>Child {index + 1}</FormText>
                             <DropdownListInput
+                                selectLabel="children-gender-select-label"
                                 labelsAndValues={[
                                     ["Male", "male"],
                                     ["Female", "female"],
@@ -79,6 +80,7 @@ const NumberChildrenCard: React.FC<CardProps> = ({
                                 onChange={getChild(fieldSetter, fields.children, index, "gender")}
                             />
                             <DropdownListInput
+                                selectLabel="children-age-select-label"
                                 labelsAndValues={[
                                     ["<1", "0"],
                                     ["1", "1"],

--- a/src/app/clients/form/formSections/NumberChildrenCard.tsx
+++ b/src/app/clients/form/formSections/NumberChildrenCard.tsx
@@ -69,7 +69,7 @@ const NumberChildrenCard: React.FC<CardProps> = ({
                         <StyledCard key={child.primaryKey}>
                             <FormText>Child {index + 1}</FormText>
                             <DropdownListInput
-                                selectLabel="children-gender-select-label"
+                                selectLabelId="children-gender-select-label"
                                 labelsAndValues={[
                                     ["Male", "male"],
                                     ["Female", "female"],
@@ -80,7 +80,7 @@ const NumberChildrenCard: React.FC<CardProps> = ({
                                 onChange={getChild(fieldSetter, fields.children, index, "gender")}
                             />
                             <DropdownListInput
-                                selectLabel="children-age-select-label"
+                                selectLabelId="children-age-select-label"
                                 labelsAndValues={[
                                     ["<1", "0"],
                                     ["1", "1"],

--- a/src/app/parcels/ActionBar/ActionsModal.tsx
+++ b/src/app/parcels/ActionBar/ActionsModal.tsx
@@ -159,7 +159,7 @@ export const DayOverviewInput: React.FC<DayOverviewInputProps> = ({
             <Heading>Location</Heading>
             {collectionCentres && (
                 <DropdownListInput
-                    selectLabel="collection-centre-select-label"
+                    selectLabelId="collection-centre-select-label"
                     onChange={onCollectionCentreChange}
                     labelsAndValues={collectionCentres}
                     defaultValue={collectionCentres[0][1]}

--- a/src/app/parcels/ActionBar/ActionsModal.tsx
+++ b/src/app/parcels/ActionBar/ActionsModal.tsx
@@ -159,6 +159,7 @@ export const DayOverviewInput: React.FC<DayOverviewInputProps> = ({
             <Heading>Location</Heading>
             {collectionCentres && (
                 <DropdownListInput
+                    selectLabel="collection-centre-select-label"
                     onChange={onCollectionCentreChange}
                     labelsAndValues={collectionCentres}
                     defaultValue={collectionCentres[0][1]}

--- a/src/app/parcels/form/formSections/CollectionCentreCard.tsx
+++ b/src/app/parcels/form/formSections/CollectionCentreCard.tsx
@@ -23,6 +23,7 @@ const CollectionCentreCard: React.FC<CollectionCentreCardProps> = ({
         >
             <>
                 <DropdownListInput
+                    selectLabel="collection-centre-select-label"
                     labelsAndValues={collectionCentresLabelsAndValues}
                     listTitle="Collection Centre"
                     defaultValue={fields.collectionCentre || collectionCentresLabelsAndValues[0][0]}

--- a/src/app/parcels/form/formSections/CollectionCentreCard.tsx
+++ b/src/app/parcels/form/formSections/CollectionCentreCard.tsx
@@ -23,7 +23,7 @@ const CollectionCentreCard: React.FC<CollectionCentreCardProps> = ({
         >
             <>
                 <DropdownListInput
-                    selectLabel="collection-centre-select-label"
+                    selectLabelId="collection-centre-select-label"
                     labelsAndValues={collectionCentresLabelsAndValues}
                     listTitle="Collection Centre"
                     defaultValue={fields.collectionCentre || collectionCentresLabelsAndValues[0][0]}

--- a/src/app/parcels/form/formSections/PackingSlotsCard.tsx
+++ b/src/app/parcels/form/formSections/PackingSlotsCard.tsx
@@ -23,6 +23,7 @@ const PackingSlotsCard: React.FC<PackingSlotsCardProps> = ({
             text="Which slot does the parcel need to be packed in?"
         >
             <DropdownListInput
+                selectLabel="packing-slot-select-label"
                 labelsAndValues={packingSlotsLabelsAndValues}
                 listTitle="Packing Slot"
                 defaultValue={fields.packingSlot}

--- a/src/app/parcels/form/formSections/PackingSlotsCard.tsx
+++ b/src/app/parcels/form/formSections/PackingSlotsCard.tsx
@@ -23,7 +23,7 @@ const PackingSlotsCard: React.FC<PackingSlotsCardProps> = ({
             text="Which slot does the parcel need to be packed in?"
         >
             <DropdownListInput
-                selectLabel="packing-slot-select-label"
+                selectLabelId="packing-slot-select-label"
                 labelsAndValues={packingSlotsLabelsAndValues}
                 listTitle="Packing Slot"
                 defaultValue={fields.packingSlot}

--- a/src/components/DataInput/DataInput.cy.tsx
+++ b/src/components/DataInput/DataInput.cy.tsx
@@ -24,7 +24,7 @@ describe("Data Input Components", () => {
         );
         cy.mount(
             <DropdownListInput
-                selectLabel="select-label"
+                selectLabelId="select-label"
                 labelsAndValues={[
                     ["A", "a"],
                     ["B", "b"],
@@ -79,7 +79,7 @@ describe("Data Input Components", () => {
         cy.mount(<PasswordInput />);
         cy.mount(
             <DropdownListInput
-                selectLabel="select-label"
+                selectLabelId="select-label"
                 labelsAndValues={[
                     ["A", "a"],
                     ["B", "b"],
@@ -214,7 +214,7 @@ describe("Data Input Components", () => {
 
             cy.mount(
                 <DropdownListInput
-                    selectLabel="select-label"
+                    selectLabelId="select-label"
                     labelsAndValues={[
                         ["A", "a"],
                         ["B", "b"],

--- a/src/components/DataInput/DataInput.cy.tsx
+++ b/src/components/DataInput/DataInput.cy.tsx
@@ -24,6 +24,7 @@ describe("Data Input Components", () => {
         );
         cy.mount(
             <DropdownListInput
+                selectLabel="select-label"
                 labelsAndValues={[
                     ["A", "a"],
                     ["B", "b"],
@@ -78,6 +79,7 @@ describe("Data Input Components", () => {
         cy.mount(<PasswordInput />);
         cy.mount(
             <DropdownListInput
+                selectLabel="select-label"
                 labelsAndValues={[
                     ["A", "a"],
                     ["B", "b"],
@@ -212,6 +214,7 @@ describe("Data Input Components", () => {
 
             cy.mount(
                 <DropdownListInput
+                    selectLabel="select-label"
                     labelsAndValues={[
                         ["A", "a"],
                         ["B", "b"],

--- a/src/components/DataInput/DropdownListInput.tsx
+++ b/src/components/DataInput/DropdownListInput.tsx
@@ -8,17 +8,17 @@ interface Props {
     listTitle?: string;
     defaultValue?: string;
     onChange?: (event: SelectChangeEvent) => void;
-    selectLabel: string;
+    selectLabelId: string;
 }
 
 const DropdownListInput: React.FC<Props> = (props) => {
     return (
         <FormControl fullWidth>
-            <InputLabel id={props.selectLabel}>{props.listTitle}</InputLabel>
+            <InputLabel id={props.selectLabelId}>{props.listTitle}</InputLabel>
             <Select
                 defaultValue={props.defaultValue ?? ""}
                 onChange={props.onChange}
-                labelId={props.selectLabel}
+                labelId={props.selectLabelId}
             >
                 {props.labelsAndValues.map(([label, value]) => {
                     return (

--- a/src/components/DataInput/DropdownListInput.tsx
+++ b/src/components/DataInput/DropdownListInput.tsx
@@ -8,16 +8,17 @@ interface Props {
     listTitle?: string;
     defaultValue?: string;
     onChange?: (event: SelectChangeEvent) => void;
+    selectLabel: string;
 }
 
 const DropdownListInput: React.FC<Props> = (props) => {
     return (
         <FormControl fullWidth>
-            <InputLabel>{props.listTitle}</InputLabel>
+            <InputLabel id={props.selectLabel}>{props.listTitle}</InputLabel>
             <Select
                 defaultValue={props.defaultValue ?? ""}
-                label={props.listTitle}
                 onChange={props.onChange}
+                labelId={props.selectLabel}
             >
                 {props.labelsAndValues.map(([label, value]) => {
                     return (


### PR DESCRIPTION
## What's changed
Add labelId for select to correspond to select label for accessibility

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| paste_here | paste_here |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA N/A
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... N/A
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
