### PR TITLE
#199 improve password reset flow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,7 @@
 name: Checks
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - dev

--- a/.github/workflows/verify-generated-database-types.yml
+++ b/.github/workflows/verify-generated-database-types.yml
@@ -1,6 +1,7 @@
 name: Verify generated database types
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - dev

--- a/src/app/auth/reset-password/route.ts
+++ b/src/app/auth/reset-password/route.ts
@@ -3,25 +3,58 @@ import { logErrorReturnLogId } from "@/logger/logger";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 
-export async function GET(request: Request): Promise<void> {
+export async function GET(request: Request): Promise<Response> {
     const { searchParams } = new URL(request.url);
     const authCode = searchParams.get("code");
 
     if (!authCode) {
-        void logErrorReturnLogId("Reset password route was visited without authorisation code.");
-        return redirect("/");
+        return logErrorAndGetErrorResponse({
+            logMessage: "Reset password route was visited without authorisation code.",
+            responseMessage: (logId) =>
+                "Failed to authenticate. You may have used the same password reset link more than once. " +
+                `If this is not the case, please contact the admins with the following log ID. Log ID: ${logId}`,
+        });
     }
 
-    const supabase = createRouteHandlerClient({ cookies });
+    try {
+        const supabase = createRouteHandlerClient({ cookies });
 
-    const { error } = await supabase.auth.exchangeCodeForSession(authCode);
+        const { error } = await supabase.auth.exchangeCodeForSession(authCode);
 
-    if (error) {
-        void logErrorReturnLogId(
-            "Failed to exchange authorisation code for a session when resetting password."
-        );
-        return redirect("/");
+        if (error) {
+            return logErrorAndGetErrorResponse({
+                logMessage:
+                    "Failed to exchange authorisation code for a session when resetting password.",
+                responseMessage: (logId) =>
+                    `Failed to authenticate. Please contact the admins with the following log ID. Log ID: ${logId}`,
+                error,
+            });
+        }
+
+        redirect("/update-password");
+    } catch (error) {
+        return logErrorAndGetErrorResponse({
+            logMessage:
+                "Failed to exchange authorisation code when resetting password, " +
+                "likely because the password reset link is visited in a different session than the one that requested the password reset link.",
+            responseMessage: (logId) =>
+                "Failed to authenticate. " +
+                "You may have visited the password reset link in a different device or browser than the one where you requested the password reset link. " +
+                `If this is not the case, please contact the admins with the following log ID. Log ID: ${logId}`,
+            error,
+        });
     }
+}
 
-    redirect("/update-password");
+async function logErrorAndGetErrorResponse({
+    logMessage,
+    responseMessage,
+    error,
+}: {
+    logMessage: string;
+    responseMessage: (logId: string) => string;
+    error?: unknown;
+}): Promise<Response> {
+    const logId = await logErrorReturnLogId(logMessage, { error });
+    return Response.json(responseMessage(logId));
 }

--- a/src/app/auth/reset-password/route.ts
+++ b/src/app/auth/reset-password/route.ts
@@ -30,8 +30,6 @@ export async function GET(request: Request): Promise<Response> {
                 error,
             });
         }
-
-        redirect("/update-password");
     } catch (error) {
         return logErrorAndGetErrorResponse({
             logMessage:
@@ -44,6 +42,8 @@ export async function GET(request: Request): Promise<Response> {
             error,
         });
     }
+
+    return redirect("/update-password");
 }
 
 async function logErrorAndGetErrorResponse({

--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -3,21 +3,21 @@
 import React, { ReactElement, useState } from "react";
 import AuthPanel, { AuthMain } from "@/components/AuthPanel";
 import { updatePassword } from "@/authentication/updatePassword";
+import { useRouter } from "next/navigation";
 
 export default function Page(): ReactElement {
     const [password, setPassword] = useState("");
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
-    const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    const router = useRouter();
 
     const initiatePasswordUpdate = (): void => {
         setErrorMessage(null);
-        setSuccessMessage(null);
 
         updatePassword(password).then(({ errorMessage }) => {
             if (errorMessage) {
                 setErrorMessage(errorMessage);
             } else {
-                setSuccessMessage("Password has been reset!");
+                router.push("/");
             }
         });
     };
@@ -31,7 +31,7 @@ export default function Page(): ReactElement {
                 submitText="Update password"
                 onSubmit={initiatePasswordUpdate}
                 errorMessage={errorMessage}
-                successMessage={successMessage}
+                successMessage={null}
             />
         </AuthMain>
     );


### PR DESCRIPTION
## What's changed
- Edit the password reset email to say that the link needs to be opened using the same machine and browser (change in Supabase)
- If the password reset link did not work as expected, we should display an error and explain that it did not succeed, and a likely reason why.
- If password reset is successful, direct user to / which should redirect to parcels page automatically (as the user is already signed in at this point)

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| N/A | Example of how the error message is displayed ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/114006382/7606e009-0865-4094-b090-2e7f31be8902) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e` (all good apart from the one Mina's fixing)

If you have made any changes to the database... NA
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
