### PR TITLE
NONE: Enable realtime through migration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,2 @@
 ## Contents
 - [Password reset flow](./password-reset-flow.md)
-- [Supabase Realtime reset](./supabase-realtime-reset)

--- a/docs/supabase-realtime-reset.md
+++ b/docs/supabase-realtime-reset.md
@@ -1,9 +1,0 @@
-## Realtime Supabase
-#### Turn on Realtime for the following tables:
-
-- [ ] clients
-- [ ] collection_centres
-- [ ] events
-- [ ] families
-- [ ] packing_slot
-- [ ] parcels

--- a/supabase/migrations/20240328103536_enable_realtime.sql
+++ b/supabase/migrations/20240328103536_enable_realtime.sql
@@ -1,0 +1,1 @@
+alter publication supabase_realtime add table clients, collection_centres, events, families, packing_slots, parcels;

--- a/supabase/migrations/20240328103536_enable_realtime.sql
+++ b/supabase/migrations/20240328103536_enable_realtime.sql
@@ -1,1 +1,1 @@
-alter publication supabase_realtime add table clients, collection_centres, events, families, packing_slots, parcels;
+alter publication supabase_realtime add table clients, collection_centres, events, families, packing_slots, parcels, website_data;


### PR DESCRIPTION
## What's changed
Enable realtime through migration.

I have checked
- [x] DB reset works successfully with realtime turned on
