### PR TITLE
#197: Show number of parcels selected

### DIFF
--- a/src/app/parcels/ActionBar/ActionAndStatusButtons.cy.tsx
+++ b/src/app/parcels/ActionBar/ActionAndStatusButtons.cy.tsx
@@ -1,4 +1,6 @@
-import ActionBar, { ActionBarProps } from "@/app/parcels/ActionBar/ActionBar";
+import ActionAndStatusButtons, {
+    ActionAndStatusButtonsProps,
+} from "@/app/parcels/ActionBar/ActionAndStatusButtons";
 import { ParcelsTableRow } from "@/app/parcels/getParcelsTableData";
 import React from "react";
 import StyleManager from "@/app/themes";
@@ -62,7 +64,7 @@ describe("Parcels - Action Bar", () => {
         },
     ];
 
-    const MockActionBar: React.FC<ActionBarProps> = ({
+    const MockActionBar: React.FC<ActionAndStatusButtonsProps> = ({
         fetchParcelsByIds: fetchSelectedParcels,
         parcelIds,
         onDeleteParcels,
@@ -70,7 +72,7 @@ describe("Parcels - Action Bar", () => {
         return (
             <Localization>
                 <StyleManager>
-                    <ActionBar
+                    <ActionAndStatusButtons
                         fetchParcelsByIds={fetchSelectedParcels}
                         onDeleteParcels={onDeleteParcels}
                         hasSavedParcelStatus={() => {}}

--- a/src/app/parcels/ActionBar/ActionAndStatusButtons.tsx
+++ b/src/app/parcels/ActionBar/ActionAndStatusButtons.tsx
@@ -9,7 +9,7 @@ import Statuses from "@/app/parcels/ActionBar/Statuses";
 import Actions from "@/app/parcels/ActionBar/Actions";
 import { ArrowDropDown } from "@mui/icons-material";
 
-export interface ActionBarProps {
+export interface ActionAndStatusButtonsProps {
     fetchParcelsByIds: (checkedParcelIds: string[]) => Promise<ParcelsTableRow[]>;
     onDeleteParcels: (parcels: ParcelsTableRow[]) => void;
     willSaveParcelStatus: () => void;
@@ -23,7 +23,7 @@ const AlertBox = styled.div`
     border-radius: 0.5rem;
 `;
 
-const ActionBar: React.FC<ActionBarProps> = (props) => {
+const ActionAndStatusButtons: React.FC<ActionAndStatusButtonsProps> = (props) => {
     const [statusAnchorElement, setStatusAnchorElement] = useState<HTMLElement | null>(null);
     const [actionAnchorElement, setActionAnchorElement] = useState<HTMLElement | null>(null);
 
@@ -77,4 +77,4 @@ const ActionBar: React.FC<ActionBarProps> = (props) => {
     );
 };
 
-export default ActionBar;
+export default ActionAndStatusButtons;

--- a/src/app/parcels/ActionBar/ActionBar.tsx
+++ b/src/app/parcels/ActionBar/ActionBar.tsx
@@ -7,7 +7,6 @@ import { ParcelsTableRow } from "@/app/parcels/getParcelsTableData";
 import Alert from "@mui/material/Alert";
 import Statuses from "@/app/parcels/ActionBar/Statuses";
 import Actions from "@/app/parcels/ActionBar/Actions";
-import { ControlContainer } from "@/components/Form/formStyling";
 import { ArrowDropDown } from "@mui/icons-material";
 
 export interface ActionBarProps {
@@ -17,10 +16,6 @@ export interface ActionBarProps {
     hasSavedParcelStatus: () => void;
     parcelIds: string[];
 }
-
-const ActionsContainer = styled(ControlContainer)`
-    justify-content: flex-end;
-`;
 
 const AlertBox = styled.div`
     display: block;
@@ -36,50 +31,48 @@ const ActionBar: React.FC<ActionBarProps> = (props) => {
 
     return (
         <>
-            <ActionsContainer>
-                <Statuses
-                    fetchParcelsByIds={props.fetchParcelsByIds}
-                    parcelIds={props.parcelIds}
-                    statusAnchorElement={statusAnchorElement}
-                    setStatusAnchorElement={setStatusAnchorElement}
-                    modalError={modalError}
-                    setModalError={setModalError}
-                    willSaveParcelStatus={props.willSaveParcelStatus}
-                    hasSavedParcelStatus={props.hasSavedParcelStatus}
-                />
-                <Actions
-                    parcelIds={props.parcelIds}
-                    fetchParcelsByIds={props.fetchParcelsByIds}
-                    onDeleteParcels={props.onDeleteParcels}
-                    actionAnchorElement={actionAnchorElement}
-                    setActionAnchorElement={setActionAnchorElement}
-                    modalError={modalError}
-                    setModalError={setModalError}
-                />
-                {modalError && (
-                    <AlertBox>
-                        <Alert severity="error">{modalError}</Alert>
-                    </AlertBox>
-                )}
-                <Button
-                    variant="contained"
-                    onClick={(event) => setStatusAnchorElement(event.currentTarget)}
-                    type="button"
-                    id="status-button"
-                    endIcon={<ArrowDropDown />}
-                >
-                    Statuses
-                </Button>
-                <Button
-                    variant="contained"
-                    onClick={(event) => setActionAnchorElement(event.currentTarget)}
-                    type="button"
-                    id="action-button"
-                    endIcon={<ArrowDropDown />}
-                >
-                    Actions
-                </Button>
-            </ActionsContainer>
+            <Statuses
+                fetchParcelsByIds={props.fetchParcelsByIds}
+                parcelIds={props.parcelIds}
+                statusAnchorElement={statusAnchorElement}
+                setStatusAnchorElement={setStatusAnchorElement}
+                modalError={modalError}
+                setModalError={setModalError}
+                willSaveParcelStatus={props.willSaveParcelStatus}
+                hasSavedParcelStatus={props.hasSavedParcelStatus}
+            />
+            <Actions
+                parcelIds={props.parcelIds}
+                fetchParcelsByIds={props.fetchParcelsByIds}
+                onDeleteParcels={props.onDeleteParcels}
+                actionAnchorElement={actionAnchorElement}
+                setActionAnchorElement={setActionAnchorElement}
+                modalError={modalError}
+                setModalError={setModalError}
+            />
+            {modalError && (
+                <AlertBox>
+                    <Alert severity="error">{modalError}</Alert>
+                </AlertBox>
+            )}
+            <Button
+                variant="contained"
+                onClick={(event) => setStatusAnchorElement(event.currentTarget)}
+                type="button"
+                id="status-button"
+                endIcon={<ArrowDropDown />}
+            >
+                Statuses
+            </Button>
+            <Button
+                variant="contained"
+                onClick={(event) => setActionAnchorElement(event.currentTarget)}
+                type="button"
+                id="action-button"
+                endIcon={<ArrowDropDown />}
+            >
+                Actions
+            </Button>
         </>
     );
 };

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -26,7 +26,7 @@ import { Filter, PaginationType } from "@/components/Tables/Filters";
 import { saveParcelStatus } from "./ActionBar/Statuses";
 import { useRouter, useSearchParams } from "next/navigation";
 import { buildTextFilter } from "@/components/Tables/TextFilter";
-import { CircularProgress, Paper } from "@mui/material";
+import { CircularProgress } from "@mui/material";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { DatabaseError } from "@/app/errorClasses";
 import { ErrorSecondaryText } from "../errorStylingandMessages";
@@ -40,8 +40,9 @@ import {
     fullNameSearch,
     phoneSearch,
     postcodeSearch,
-    voucherSearch,
+    voucherSearch
 } from "@/app/parcels/parcelsTableFilters";
+import { ActionsContainer } from "@/components/Form/formStyling";
 
 export const parcelTableHeaderKeysAndLabels: TableHeaders<ParcelsTableRow> = [
     ["iconsColumn", "Flags"],
@@ -188,18 +189,6 @@ const PreTableControls = styled.div`
     gap: 0.5rem;
     align-items: stretch;
     justify-content: space-between;
-`;
-
-const ActionsContainer = styled(Paper)`
-    flex-grow: 1;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    padding: 1rem;
-    gap: 0.5rem;
-    align-items: center;
-    border-radius: 0.5rem;
-    background-color: ${(props) => props.theme.main.background[5]};
 `;
 
 function getSelectedParcelCountMessage(numberOfSelectedParcels: number): string | null {

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -5,7 +5,6 @@ import React, { Suspense, useEffect, useRef, useState } from "react";
 import styled, { useTheme } from "styled-components";
 import { ParcelsTableRow } from "@/app/parcels/getParcelsTableData";
 import { formatDatetimeAsDate } from "@/app/parcels/getExpandedParcelDetails";
-import { ControlContainer } from "@/components/Form/formStyling";
 import { DateRangeState } from "@/components/DateRangeInputs/DateRangeInputs";
 import FlaggedForAttentionIcon from "@/components/Icons/FlaggedForAttentionIcon";
 import PhoneIcon from "@/components/Icons/PhoneIcon";
@@ -37,7 +36,7 @@ import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 import { Database } from "@/databaseTypesFile";
 import { buildTextFilter } from "@/components/Tables/TextFilter";
 import { dateFilter } from "@/components/Tables/DateFilter";
-import { CircularProgress } from "@mui/material";
+import { CircularProgress, Paper } from "@mui/material";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { DatabaseError } from "@/app/errorClasses";
 import { ErrorSecondaryText } from "../errorStylingandMessages";
@@ -195,9 +194,26 @@ const PreTableControls = styled.div`
     justify-content: space-between;
 `;
 
-const ActionsContainer = styled(ControlContainer)`
+const ActionsContainer = styled(Paper)`
+    flex-grow: 1;
+    display: flex;
+    flex-wrap: wrap;
     justify-content: flex-end;
+    padding: 1rem;
+    gap: 0.5rem;
+    align-items: center;
+    border-radius: 0.5rem;
+    background-color: ${(props) => props.theme.main.background[5]};
 `;
+
+function getSelectedParcelCountMessage(numberOfSelectedParcels: number): string | null {
+    if (numberOfSelectedParcels === 0) {
+        return null;
+    }
+    return numberOfSelectedParcels === 1
+        ? "1 parcel selected"
+        : `${numberOfSelectedParcels} parcels selected`;
+}
 
 const parcelIdParam = "parcelId";
 
@@ -437,6 +453,8 @@ const ParcelsPage: React.FC<{}> = () => {
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     const parcelsTableFetchAbortController = useRef<AbortController | null>(null);
+
+    const selectedParcelMessage = getSelectedParcelCountMessage(checkedParcelIds.length);
 
     useEffect(() => {
         if (parcelId) {
@@ -774,6 +792,8 @@ const ParcelsPage: React.FC<{}> = () => {
         <>
             <PreTableControls>
                 <ActionsContainer>
+                    {selectedParcelMessage && <span>{selectedParcelMessage}</span>}
+
                     <ActionAndStatusButtons
                         fetchParcelsByIds={getCheckedParcelsData}
                         onDeleteParcels={deleteParcels}

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -18,7 +18,7 @@ import Icon from "@/components/Icons/Icon";
 import { faBoxArchive } from "@fortawesome/free-solid-svg-icons";
 import Modal from "@/components/Modal/Modal";
 import TableSurface from "@/components/Tables/TableSurface";
-import ActionBar from "@/app/parcels/ActionBar/ActionBar";
+import ActionAndStatusButtons from "@/app/parcels/ActionBar/ActionAndStatusButtons";
 import { ButtonsDiv, Centerer, ContentDiv, OutsideDiv } from "@/components/Modal/ModalFormStyles";
 import LinkButton from "@/components/Buttons/LinkButton";
 import supabase from "@/supabaseClient";
@@ -774,7 +774,7 @@ const ParcelsPage: React.FC<{}> = () => {
         <>
             <PreTableControls>
                 <ActionsContainer>
-                    <ActionBar
+                    <ActionAndStatusButtons
                         fetchParcelsByIds={getCheckedParcelsData}
                         onDeleteParcels={deleteParcels}
                         willSaveParcelStatus={() => setIsLoading(true)}

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -209,8 +209,8 @@ async function getClientIdForSelectedParcel(parcelId: string): Promise<string> {
 
     if (error) {
         const message = `Failed to fetch client ID for a parcel with ID ${parcelId}`;
-        void logErrorReturnLogId(message, { error });
-        throw new Error(message);
+        const logId = await logErrorReturnLogId(message, { error });
+        throw new Error(message + ` Log ID: ${logId}`);
     }
 
     return data.client_id;
@@ -255,15 +255,19 @@ const ParcelsPage: React.FC<{}> = () => {
 
     const selectedParcelMessage = getSelectedParcelCountMessage(checkedParcelIds.length);
 
-    const fetchAndSetClientIdForSelectedParcel = (): void => {
+    const fetchAndSetClientIdForSelectedParcel = useCallback((): void => {
         if (parcelId === null) {
             return;
         }
 
         getClientIdForSelectedParcel(parcelId)
             .then((clientId) => setClientIdForSelectedParcel(clientId))
-            .catch();
-    };
+            .catch((error) => {
+                if (error instanceof Error) {
+                    setErrorMessage(error.message);
+                }
+            });
+    }, [parcelId]);
 
     useEffect(() => {
         if (parcelId) {

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -195,6 +195,10 @@ const PreTableControls = styled.div`
     justify-content: space-between;
 `;
 
+const ActionsContainer = styled(ControlContainer)`
+    justify-content: flex-end;
+`;
+
 const parcelIdParam = "parcelId";
 
 const fullNameSearch = (
@@ -769,14 +773,15 @@ const ParcelsPage: React.FC<{}> = () => {
     return (
         <>
             <PreTableControls>
-                <ControlContainer />
-                <ActionBar
-                    fetchParcelsByIds={getCheckedParcelsData}
-                    onDeleteParcels={deleteParcels}
-                    willSaveParcelStatus={() => setIsLoading(true)}
-                    hasSavedParcelStatus={() => setIsLoading(false)}
-                    parcelIds={checkedParcelIds}
-                />
+                <ActionsContainer>
+                    <ActionBar
+                        fetchParcelsByIds={getCheckedParcelsData}
+                        onDeleteParcels={deleteParcels}
+                        willSaveParcelStatus={() => setIsLoading(true)}
+                        hasSavedParcelStatus={() => setIsLoading(false)}
+                        parcelIds={checkedParcelIds}
+                    />
+                </ActionsContainer>
             </PreTableControls>
             {areFiltersLoadingForFirstTime ? (
                 <Centerer>

--- a/src/app/parcels/parcelsTableFilters.ts
+++ b/src/app/parcels/parcelsTableFilters.ts
@@ -1,0 +1,224 @@
+"use client"
+
+import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
+import { Database } from "@/databaseTypesFile";
+import { DateRangeState } from "@/components/DateRangeInputs/DateRangeInputs";
+import { Filter, PaginationType } from "@/components/Tables/Filters";
+import { ParcelsTableRow } from "@/app/parcels/getParcelsTableData";
+import { dateFilter } from "@/components/Tables/DateFilter";
+import supabase from "@/supabaseClient";
+import { logErrorReturnLogId } from "@/logger/logger";
+import { DatabaseError } from "@/app/errorClasses";
+import { checklistFilter } from "@/components/Tables/ChecklistFilter";
+import { CollectionCentresOptions } from "@/app/parcels/fetchParcelTableData";
+
+interface packingSlotOptionsSet {
+    key: string;
+    value: string;
+}
+
+export const fullNameSearch = (
+    query: PostgrestFilterBuilder<Database["public"], any, any>,
+    state: string
+): PostgrestFilterBuilder<Database["public"], any, any> => {
+    return query.ilike("client_full_name", `%${state}%`);
+};
+
+export const postcodeSearch = (
+    query: PostgrestFilterBuilder<Database["public"], any, any>,
+    state: string
+): PostgrestFilterBuilder<Database["public"], any, any> => {
+    return query.ilike("client_address_postcode", `%${state}%`);
+};
+
+export const familySearch = (
+    query: PostgrestFilterBuilder<Database["public"], any, any>,
+    state: string
+): PostgrestFilterBuilder<Database["public"], any, any> => {
+    if (state === "") {
+        return query;
+    }
+    if ("single".includes(state.toLowerCase())) {
+        return query.lte("family_count", 1);
+    }
+    if ("family of".includes(state.toLowerCase())) {
+        return query.gte("family_count", 2);
+    }
+    const stateAsNumber = Number(state);
+    if (Number.isNaN(stateAsNumber) || stateAsNumber === 0) {
+        return query.eq("family_count", -1);
+    }
+    if (stateAsNumber >= 10) {
+        return query.gte("family_count", 10);
+    }
+    if (stateAsNumber === 1) {
+        return query.lte("family_count", 1);
+    }
+    return query.eq("family_count", Number(state));
+};
+
+export const phoneSearch = (
+    query: PostgrestFilterBuilder<Database["public"], any, any>,
+    state: string
+): PostgrestFilterBuilder<Database["public"], any, any> => {
+    return query.ilike("client_phone_number", `%${state}%`);
+};
+
+export const voucherSearch = (
+    query: PostgrestFilterBuilder<Database["public"], any, any>,
+    state: string
+): PostgrestFilterBuilder<Database["public"], any, any> => {
+    return query.ilike("voucher_number", `%${state}%`);
+};
+
+export const buildDateFilter = (
+    initialState: DateRangeState
+): Filter<ParcelsTableRow, DateRangeState> => {
+    const dateSearch = (
+        query: PostgrestFilterBuilder<Database["public"], any, any>,
+        state: DateRangeState
+    ): PostgrestFilterBuilder<Database["public"], any, any> => {
+        return query.gte("packing_date", state.from).lte("packing_date", state.to);
+    };
+    return dateFilter<ParcelsTableRow>({
+        key: "packingDate",
+        label: "",
+        methodConfig: { paginationType: PaginationType.Server, method: dateSearch },
+        initialState: initialState
+    });
+};
+
+export const buildDeliveryCollectionFilter = async (): Promise<
+    Filter<ParcelsTableRow, string[]>
+> => {
+    const deliveryCollectionSearch = (
+        query: PostgrestFilterBuilder<Database["public"], any, any>,
+        state: string[]
+    ): PostgrestFilterBuilder<Database["public"], any, any> => {
+        return query.in("collection_centre_acronym", state);
+    };
+
+    const keySet = new Set();
+    const { data, error } = await supabase
+        .from("parcels_plus")
+        .select("collection_centre_name, collection_centre_acronym");
+    if (error) {
+        const logId = await logErrorReturnLogId(
+            "Error with fetch: Collection centre filter options",
+            error
+        );
+        throw new DatabaseError("fetch", "collection centre filter options", logId);
+    }
+    const optionsResponse = data ?? [];
+    const optionsSet: CollectionCentresOptions[] = optionsResponse.reduce<
+        CollectionCentresOptions[]
+    >((filteredOptions, row) => {
+        if (
+            row?.collection_centre_acronym &&
+            row.collection_centre_name &&
+            !keySet.has(row.collection_centre_acronym)
+        ) {
+            keySet.add(row.collection_centre_acronym);
+            filteredOptions.push({
+                name: row.collection_centre_name,
+                acronym: row.collection_centre_acronym
+            });
+        }
+        return filteredOptions.sort();
+    }, []);
+
+    return checklistFilter<ParcelsTableRow>({
+        key: "deliveryCollection",
+        filterLabel: "Collection",
+        itemLabelsAndKeys: optionsSet.map((option) => [option!.name, option!.acronym]),
+        initialCheckedKeys: optionsSet.map((option) => option!.acronym),
+        methodConfig: { paginationType: PaginationType.Server, method: deliveryCollectionSearch }
+    });
+};
+
+export const buildLastStatusFilter = async (): Promise<Filter<ParcelsTableRow, string[]>> => {
+    const lastStatusSearch = (
+        query: PostgrestFilterBuilder<Database["public"], any, any>,
+        state: string[]
+    ): PostgrestFilterBuilder<Database["public"], any, any> => {
+        if (state.includes("None")) {
+            return query.or(
+                `last_status_event_name.is.null,last_status_event_name.in.(${state.join(",")})`
+            );
+        } else {
+            return query.in("last_status_event_name", state);
+        }
+    };
+
+    const keySet = new Set();
+    const { data, error } = await supabase.from("status_order").select("event_name");
+    if (error) {
+        const logId = await logErrorReturnLogId("Error with fetch: Last status filter options");
+        throw new DatabaseError("fetch", "last status filter options", logId);
+    }
+    const optionsResponse = data ?? [];
+    const optionsSet: string[] = optionsResponse.reduce<string[]>((filteredOptions, row) => {
+        if (row.event_name && !keySet.has(row.event_name)) {
+            keySet.add(row.event_name);
+            filteredOptions.push(row.event_name);
+        }
+        return filteredOptions.sort();
+    }, []);
+    data && optionsSet.push("None");
+
+    return checklistFilter<ParcelsTableRow>({
+        key: "lastStatus",
+        filterLabel: "Last Status",
+        itemLabelsAndKeys: optionsSet.map((value) => [value, value]),
+        initialCheckedKeys: optionsSet.filter((option) => option !== "Request Deleted"),
+        methodConfig: { paginationType: PaginationType.Server, method: lastStatusSearch }
+    });
+};
+
+export const buildPackingSlotFilter = async (): Promise<Filter<ParcelsTableRow, string[]>> => {
+    const packingSlotSearch = (
+        query: PostgrestFilterBuilder<Database["public"], any, any>,
+        state: string[]
+    ): PostgrestFilterBuilder<Database["public"], any, any> => {
+        return query.in("packing_slot_name", state);
+    };
+
+    const keySet = new Set();
+
+    const { data, error } = await supabase.from("packing_slots").select("name, is_shown");
+    if (error) {
+        const logId = await logErrorReturnLogId(
+            "Error with fetch: Packing slot filter options",
+            error
+        );
+        throw new DatabaseError("fetch", "packing slot filter options", logId);
+    }
+
+    const optionsResponse = data ?? [];
+
+    const optionsSet = optionsResponse.reduce<packingSlotOptionsSet[]>((filteredOptions, row) => {
+        if (!row.name || keySet.has(row.name)) {
+            return filteredOptions;
+        }
+
+        if (row.is_shown) {
+            keySet.add(row.name);
+            filteredOptions.push({ key: row.name, value: row.name });
+        } else {
+            keySet.add(row.name);
+            filteredOptions.push({ key: row.name, value: `${row.name} (inactive)` });
+        }
+
+        return filteredOptions;
+    }, []);
+
+    optionsSet.sort();
+
+    return checklistFilter<ParcelsTableRow>({
+        key: "packingSlot",
+        filterLabel: "Packing Slot",
+        itemLabelsAndKeys: optionsSet.map((option) => [option.value, option.key]),
+        initialCheckedKeys: optionsSet.map((option) => option.key),
+        methodConfig: { paginationType: PaginationType.Server, method: packingSlotSearch }
+    });
+};

--- a/src/app/parcels/parcelsTableFilters.ts
+++ b/src/app/parcels/parcelsTableFilters.ts
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 import { Database } from "@/databaseTypesFile";
@@ -84,7 +84,7 @@ export const buildDateFilter = (
         key: "packingDate",
         label: "",
         methodConfig: { paginationType: PaginationType.Server, method: dateSearch },
-        initialState: initialState
+        initialState: initialState,
     });
 };
 
@@ -121,7 +121,7 @@ export const buildDeliveryCollectionFilter = async (): Promise<
             keySet.add(row.collection_centre_acronym);
             filteredOptions.push({
                 name: row.collection_centre_name,
-                acronym: row.collection_centre_acronym
+                acronym: row.collection_centre_acronym,
             });
         }
         return filteredOptions.sort();
@@ -132,7 +132,7 @@ export const buildDeliveryCollectionFilter = async (): Promise<
         filterLabel: "Collection",
         itemLabelsAndKeys: optionsSet.map((option) => [option!.name, option!.acronym]),
         initialCheckedKeys: optionsSet.map((option) => option!.acronym),
-        methodConfig: { paginationType: PaginationType.Server, method: deliveryCollectionSearch }
+        methodConfig: { paginationType: PaginationType.Server, method: deliveryCollectionSearch },
     });
 };
 
@@ -171,7 +171,7 @@ export const buildLastStatusFilter = async (): Promise<Filter<ParcelsTableRow, s
         filterLabel: "Last Status",
         itemLabelsAndKeys: optionsSet.map((value) => [value, value]),
         initialCheckedKeys: optionsSet.filter((option) => option !== "Request Deleted"),
-        methodConfig: { paginationType: PaginationType.Server, method: lastStatusSearch }
+        methodConfig: { paginationType: PaginationType.Server, method: lastStatusSearch },
     });
 };
 
@@ -219,6 +219,6 @@ export const buildPackingSlotFilter = async (): Promise<Filter<ParcelsTableRow, 
         filterLabel: "Packing Slot",
         itemLabelsAndKeys: optionsSet.map((option) => [option.value, option.key]),
         initialCheckedKeys: optionsSet.map((option) => option.key),
-        methodConfig: { paginationType: PaginationType.Server, method: packingSlotSearch }
+        methodConfig: { paginationType: PaginationType.Server, method: packingSlotSearch },
     });
 };

--- a/src/components/Form/formStyling.tsx
+++ b/src/components/Form/formStyling.tsx
@@ -66,14 +66,3 @@ export const GappedDiv = styled.div`
     flex-direction: column;
     gap: 1em;
 `;
-
-export const ControlContainer = styled(Paper)`
-    flex-grow: 1;
-    display: flex;
-    flex-wrap: wrap;
-    padding: 1rem;
-    gap: 0.5rem;
-    align-items: center;
-    border-radius: 0.5rem;
-    background-color: ${(props) => props.theme.main.background[5]};
-`;

--- a/src/components/Form/formStyling.tsx
+++ b/src/components/Form/formStyling.tsx
@@ -66,3 +66,15 @@ export const GappedDiv = styled.div`
     flex-direction: column;
     gap: 1em;
 `;
+
+export const ActionsContainer = styled(Paper)`
+    flex-grow: 1;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    padding: 1rem;
+    gap: 0.5rem;
+    align-items: center;
+    border-radius: 0.5rem;
+    background-color: ${(props) => props.theme.main.background[5]};
+`;


### PR DESCRIPTION
## What's changed
- Show the number of selected parcels on the parcels page
- Removed the empty container shown above the parcels page
- Clean up of ParcelsPage.tsx (see comments)

I've tested against the current dev website to spot check various filters to make sure the results are identical.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| paste_here | paste_here |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
