### PR TITLE
VFB-172 error fix parcelId function

### DIFF
--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -443,6 +443,9 @@ const ParcelsPage: React.FC<{}> = () => {
 
     useEffect(() => {
         const fetchAndSetClientIdForSelectedParcel = async (): Promise<void> => {
+            if (!parcelId) {
+                return;
+            }
             const { data, error } = await supabase
                 .from("parcels")
                 .select("client_id")

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -153,7 +153,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
                 packingSlot: Errors.invalidPackingSlot,
             }));
         }
-    }, []);
+    }, [editMode, packingSlotIsShown]);
 
     const formSections =
         fields.shippingMethod === "Collection"


### PR DESCRIPTION
## What's changed
Error handling added to prevent error when loading parcels page

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [x] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [x] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [x] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - NO (remove as appropriate)
