### PR TITLE
NONE: Add include-all flag when deploying database

### DIFF
--- a/.github/workflows/deploy-dev-database.yml
+++ b/.github/workflows/deploy-dev-database.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Link to the project
         run: npx supabase link --project-ref $SUPABASE_DEV_PROJECT_ID
       - name: Dry run the migration
-        run: npx supabase db push --dry-run
+        run: npx supabase db push --dry-run --include-all
       - name: Apply the migration
-        run: npx supabase db push
+        run: npx supabase db push --include-all

--- a/.github/workflows/deploy-dry-prod-database.yml
+++ b/.github/workflows/deploy-dry-prod-database.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Link to the project
         run: npx supabase link --project-ref $SUPABASE_PROD_PROJECT_ID
       - name: Dry run the migration
-        run: npx supabase db push --dry-run
+        run: npx supabase db push --dry-run --include-all

--- a/.github/workflows/deploy-prod-database.yml
+++ b/.github/workflows/deploy-prod-database.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Link to the project
         run: npx supabase link --project-ref $SUPABASE_PROD_PROJECT_ID
       - name: Apply the migration
-        run: npx supabase db push
+        run: npx supabase db push --include-all


### PR DESCRIPTION
## What's changed
Previously, the migration could only run if the new migration files are timestamped after the current latest migration file. We want to run all migration files that are not in in the current db instead.
