### PR TITLE
VFB-135: display up to 100 parcels

### DIFF
--- a/.snaplet/snaplet-client.d.ts
+++ b/.snaplet/snaplet-client.d.ts
@@ -122,6 +122,7 @@ type Override = {
       created_at?: string;
       updated_at?: string;
       authentication_method?: string;
+      auth_code_issued_at?: string;
       saml_relay_states?: string;
     };
   }
@@ -586,6 +587,7 @@ export interface Fingerprint {
   flowStates?: {
     createdAt?: FingerprintDateField;
     updatedAt?: FingerprintDateField;
+    authCodeIssuedAt?: FingerprintDateField;
     samlRelayStates?: FingerprintRelationField;
   }
   hooks?: {

--- a/.snaplet/snaplet.d.ts
+++ b/.snaplet/snaplet.d.ts
@@ -90,6 +90,7 @@ interface Table_auth_flow_state {
   created_at: string | null;
   updated_at: string | null;
   authentication_method: string;
+  auth_code_issued_at: string | null;
 }
 interface Table_supabase_functions_hooks {
   id: number;
@@ -249,6 +250,7 @@ interface Table_public_parcels {
   collection_datetime: string | null;
   voucher_number: string | null;
   packing_slot: string | null;
+}
 interface Table_public_profiles {
   primary_key: string;
   first_name: string | null;
@@ -427,8 +429,8 @@ interface Schema_public {
   lists_hotel: Table_public_lists_hotel;
   packing_slots: Table_public_packing_slots;
   parcels: Table_public_parcels;
-  status_order: Table_public_status_order;
   profiles: Table_public_profiles;
+  status_order: Table_public_status_order;
   website_data: Table_public_website_data;
 }
 interface Schema_realtime {

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -574,6 +574,7 @@ const ParcelsPage: React.FC<{}> = () => {
                                 filteredCount: filteredParcelCount,
                                 onPageChange: setCurrentPage,
                                 onPerPageChange: setParcelCountPerPage,
+                                rowsPerPageOptions: [10, 25, 50, 100],
                             }}
                             headerKeysAndLabels={parcelTableHeaderKeysAndLabels}
                             columnDisplayFunctions={parcelTableColumnDisplayFunctions}

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -103,6 +103,7 @@ export type PaginationConfig =
           filteredCount: number;
           onPageChange: (newPage: number) => void;
           onPerPageChange: (perPage: number) => void;
+          rowsPerPageOptions?: number[];
       }
     | {
           enablePagination: false;
@@ -428,6 +429,11 @@ const Table = <Data,>({
                         paginationTotalRows={
                             paginationConfig.enablePagination
                                 ? paginationConfig.filteredCount
+                                : undefined
+                        }
+                        paginationRowsPerPageOptions={
+                            paginationConfig.enablePagination
+                                ? paginationConfig.rowsPerPageOptions
                                 : undefined
                         }
                         paginationDefaultPage={paginationConfig.enablePagination ? 1 : undefined}


### PR DESCRIPTION
## What's changed
Currently we have options to show up to 10, 15, 20, 25 or 30 items on the parcels page. This has been changed to show 10, 25, 50 or 100 parcels instead.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/114006382/b162182c-924e-483e-83f9-babedfb1318f) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/114006382/48e598c8-1222-4c31-9eee-b73a354b82fe) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... Nope
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect.
