### PR TITLE
VFB-137-FIX: Higher contrast rows in dark and green on hover

### DIFF
--- a/cypress/e2e/themes.cy.ts
+++ b/cypress/e2e/themes.cy.ts
@@ -10,7 +10,7 @@ describe("Light and dark mode switch works", () => {
 
     it("Switching to Dark Mode Works", () => {
         cy.get("[type='checkbox']").first().check();
-        cy.get("body").should("have.css", "background-color", hexToRgb("#212121"));
+        cy.get("body").should("have.css", "background-color", hexToRgb("#2d2d2d"));
     });
 
     it("Switching back to Light Mode Works", () => {

--- a/src/app/themes.tsx
+++ b/src/app/themes.tsx
@@ -125,7 +125,7 @@ export const lightTheme: DefaultTheme = {
 export const darkTheme: DefaultTheme = {
     light: false,
     main: {
-        background: ["#111111", "#161616", "#212121", "#2d2d2d"],
+        background: ["#111111", "#212121", "#2d2d2d", "#313131"],
         foreground: ["#d9d9d9", "#d9d9d9", "#d9d9d9", "#d9d9d9"],
         largeForeground: ["#d9d9d9", "#d9d9d9", "#d9d9d9", "#d9d9d9"],
         lighterForeground: ["#969696", "#969696", "#969696", "#bbbbbb"],

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -9,7 +9,7 @@ import {
     faPenToSquare,
     faTrashAlt,
 } from "@fortawesome/free-solid-svg-icons";
-import { CircularProgress, NoSsr } from "@mui/material";
+import { CircularProgress, NoSsr, useThemeProps } from "@mui/material";
 import IconButton from "@mui/material/IconButton/IconButton";
 import React, { useState } from "react";
 import DataTable, { TableColumn } from "react-data-table-component";
@@ -564,7 +564,7 @@ const TableStyling = styled.div`
     }
 
     & div.rdt_TableRow:hover {
-        background-color: ${(props) => props.theme.main.background[2]};
+        background-color: ${(props) => props.theme.primary.background[1]};
     }
 
     & .rdt_TableHeadRow {

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -9,7 +9,7 @@ import {
     faPenToSquare,
     faTrashAlt,
 } from "@fortawesome/free-solid-svg-icons";
-import { CircularProgress, NoSsr, useThemeProps } from "@mui/material";
+import { CircularProgress, NoSsr } from "@mui/material";
 import IconButton from "@mui/material/IconButton/IconButton";
 import React, { useState } from "react";
 import DataTable, { TableColumn } from "react-data-table-component";


### PR DESCRIPTION
## What's changed

- rows in dark mode are higher contrast
- hovered rows are light green in both modes

## Screenshots / Videos
| Before     | After      |
|------------|------------|
|![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/24893a0e-4e6a-4e9b-9514-ce6bbe60aafb)![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/0e30cc1e-2957-40d3-8b48-db305f624c7c)|![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/2ff443f4-f0cf-47dc-98a1-f9fc5953b663)![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/fce413d4-dec7-4561-9fa6-71e9b363d4a5)|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`
