### PR TITLE
VFB-137: FIX 2 - green hover on data grids

### DIFF
--- a/src/app/admin/common/StyledDataGrid.tsx
+++ b/src/app/admin/common/StyledDataGrid.tsx
@@ -28,6 +28,12 @@ const DataGridStyling = styled(DataGrid)`
         background-color: ${(props) => props.theme.main.background[0]};
         color: ${(props) => props.theme.main.foreground[2]};
     }
+
+    & .MuiDataGrid-virtualScrollerRenderZone {
+        & :hover {
+            background-color: ${(props) => props.theme.primary.background[1]};
+        }
+    }
 `;
 
 const StyledDataGrid: React.FC<DataGridProps> = (props) => <DataGridStyling {...props} />;


### PR DESCRIPTION
## What's changed
Datagrids (websitre data table and packing slots) have green rows on hover.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test:e2e`
