### PR TITLE
VFB-192: Add audit logs when an invite link is sent

### DIFF
--- a/.snaplet/snaplet-client.d.ts
+++ b/.snaplet/snaplet-client.d.ts
@@ -148,6 +148,7 @@ type Override = {
       gender?: string;
       age?: string;
       clients?: string;
+      audit_log?: string;
     };
   }
   flow_state?: {
@@ -401,6 +402,7 @@ type Override = {
       telephone_number?: string;
       user_id?: string;
       users?: string;
+      audit_log?: string;
     };
   }
   refresh_tokens?: {
@@ -760,7 +762,8 @@ export interface Fingerprint {
     eventsByParcelId?: FingerprintRelationField;
   }
   profiles?: {
-    user?: FingerprintRelationField;
+    userByPrimaryKey?: FingerprintRelationField;
+    auditLogsByProfileId?: FingerprintRelationField;
   }
   refreshTokens?: {
     id?: FingerprintNumberField;
@@ -847,7 +850,7 @@ export interface Fingerprint {
     mfaFactors?: FingerprintRelationField;
     sessions?: FingerprintRelationField;
     auditLogs?: FingerprintRelationField;
-    profiles?: FingerprintRelationField;
+    profilesByPrimaryKey?: FingerprintRelationField;
   }
   websiteData?: {
     auditLogsByWebsiteData?: FingerprintRelationField;

--- a/.snaplet/snaplet-client.d.ts
+++ b/.snaplet/snaplet-client.d.ts
@@ -83,15 +83,6 @@ type Override = {
       objects?: string;
     };
   }
-  channels?: {
-    name?: string;
-    fields?: {
-      id?: string;
-      name?: string;
-      inserted_at?: string;
-      updated_at?: string;
-    };
-  }
   clients?: {
     name?: string;
     fields?: {
@@ -148,7 +139,6 @@ type Override = {
       gender?: string;
       age?: string;
       clients?: string;
-      audit_log?: string;
     };
   }
   flow_state?: {
@@ -456,13 +446,6 @@ type Override = {
       version?: string;
     };
   }
-  realtime_schema_migrations?: {
-    name?: string;
-    fields?: {
-      version?: string;
-      inserted_at?: string;
-    };
-  }
   supabase_migrations_schema_migrations?: {
     name?: string;
     fields?: {
@@ -533,18 +516,6 @@ type Override = {
       event_name?: string;
       workflow_order?: string;
       audit_log?: string;
-    };
-  }
-  subscription?: {
-    name?: string;
-    fields?: {
-      id?: string;
-      subscription_id?: string;
-      entity?: string;
-      filters?: string;
-      claims?: string;
-      claims_role?: string;
-      created_at?: string;
     };
   }
   users?: {
@@ -650,11 +621,6 @@ export interface Fingerprint {
     updatedAt?: FingerprintDateField;
     fileSizeLimit?: FingerprintNumberField;
     objects?: FingerprintRelationField;
-  }
-  channels?: {
-    id?: FingerprintNumberField;
-    insertedAt?: FingerprintDateField;
-    updatedAt?: FingerprintDateField;
   }
   clients?: {
     auditLogsByClientId?: FingerprintRelationField;
@@ -786,10 +752,6 @@ export interface Fingerprint {
   authSchemaMigrations?: {
 
   }
-  realtimeSchemaMigrations?: {
-    version?: FingerprintNumberField;
-    insertedAt?: FingerprintDateField;
-  }
   supabaseMigrationsSchemaMigrations?: {
 
   }
@@ -822,11 +784,6 @@ export interface Fingerprint {
   statusOrders?: {
     workflowOrder?: FingerprintNumberField;
     auditLogsByStatusOrder?: FingerprintRelationField;
-  }
-  subscriptions?: {
-    id?: FingerprintNumberField;
-    claims?: FingerprintJsonField;
-    createdAt?: FingerprintDateField;
   }
   users?: {
     emailConfirmedAt?: FingerprintDateField;

--- a/.snaplet/snaplet.d.ts
+++ b/.snaplet/snaplet.d.ts
@@ -40,6 +40,7 @@ interface Table_public_audit_log {
   wasSuccess: boolean;
   log_id: string | null;
 }
+  profile_id: string | null;
 interface Table_auth_audit_log_entries {
   instance_id: string | null;
   id: string;
@@ -546,6 +547,7 @@ interface Tables_relationships {
        audit_log_packing_slot_id_fkey: "public.packing_slots";
        audit_log_parcel_id_fkey: "public.parcels";
        audit_log_status_order_fkey: "public.status_order";
+       audit_log_profile_id_fkey: "public.profiles";
        audit_log_website_data_fkey: "public.website_data";
     };
     children: {
@@ -693,7 +695,7 @@ interface Tables_relationships {
        profiles_user_id_fkey: "auth.users";
     };
     children: {
-
+       audit_log_profile_id_fkey: "public.audit_log";
     };
   };
   "auth.refresh_tokens": {

--- a/.snaplet/snaplet.d.ts
+++ b/.snaplet/snaplet.d.ts
@@ -11,8 +11,6 @@ type Enum_pgsodium_key_status = 'default' | 'expired' | 'invalid' | 'valid';
 type Enum_pgsodium_key_type = 'aead-det' | 'aead-ietf' | 'auth' | 'generichash' | 'hmacsha256' | 'hmacsha512' | 'kdf' | 'secretbox' | 'secretstream' | 'shorthash' | 'stream_xchacha20';
 type Enum_public_gender = 'female' | 'male' | 'other';
 type Enum_public_role = 'admin' | 'caller';
-type Enum_realtime_action = 'DELETE' | 'ERROR' | 'INSERT' | 'TRUNCATE' | 'UPDATE';
-type Enum_realtime_equality_op = 'eq' | 'gt' | 'gte' | 'in' | 'lt' | 'lte' | 'neq';
 interface Table_net_http_response {
   id: number | null;
   status_code: number | null;
@@ -59,12 +57,6 @@ interface Table_storage_buckets {
   file_size_limit: number | null;
   allowed_mime_types: string[] | null;
   owner_id: string | null;
-}
-interface Table_realtime_channels {
-  id: number;
-  name: string;
-  inserted_at: string;
-  updated_at: string;
 }
 interface Table_public_clients {
   primary_key: string;
@@ -319,10 +311,6 @@ interface Table_auth_saml_relay_states {
 interface Table_auth_schema_migrations {
   version: string;
 }
-interface Table_realtime_schema_migrations {
-  version: number;
-  inserted_at: string | null;
-}
 interface Table_supabase_migrations_schema_migrations {
   version: string;
   statements: string[] | null;
@@ -367,34 +355,6 @@ interface Table_auth_sso_providers {
 interface Table_public_status_order {
   event_name: string;
   workflow_order: number;
-}
-interface Table_realtime_subscription {
-  id: number;
-  subscription_id: string;
-  /**
-  * We couldn't determine the type of this column. The type might be coming from an unknown extension
-  * or be specific to your database. Please if it's a common used type report this issue so we can fix it!
-  * Otherwise, please manually type this column by casting it to the correct type.
-  * @example
-  * Here is a cast example for copycat use:
-  * ```
-  * copycat.scramble(row.unknownColumn as string)
-  * ```
-  */
-  entity: unknown;
-  /**
-  * We couldn't determine the type of this column. The type might be coming from an unknown extension
-  * or be specific to your database. Please if it's a common used type report this issue so we can fix it!
-  * Otherwise, please manually type this column by casting it to the correct type.
-  * @example
-  * Here is a cast example for copycat use:
-  * ```
-  * copycat.scramble(row.unknownColumn as string)
-  * ```
-  */
-  filters: unknown[];
-  claims: Json;
-  created_at: string;
 }
 interface Table_auth_users {
   instance_id: string | null;
@@ -492,9 +452,7 @@ interface Schema_public {
   website_data: Table_public_website_data;
 }
 interface Schema_realtime {
-  channels: Table_realtime_channels;
-  schema_migrations: Table_realtime_schema_migrations;
-  subscription: Table_realtime_subscription;
+
 }
 interface Schema_storage {
   buckets: Table_storage_buckets;

--- a/src/databaseTypesFile.ts
+++ b/src/databaseTypesFile.ts
@@ -16,12 +16,14 @@ export type Database = {
           collection_centre_id: string | null
           content: Json | null
           event_id: string | null
+          family_member_id: string | null
           list_hotel_id: string | null
           list_id: string | null
           log_id: string | null
           packing_slot_id: string | null
           parcel_id: string | null
           primary_key: string
+          profile_id: string | null
           status_order: string | null
           user_id: string
           wasSuccess: boolean
@@ -33,12 +35,14 @@ export type Database = {
           collection_centre_id?: string | null
           content?: Json | null
           event_id?: string | null
+          family_member_id?: string | null
           list_hotel_id?: string | null
           list_id?: string | null
           log_id?: string | null
           packing_slot_id?: string | null
           parcel_id?: string | null
           primary_key?: string
+          profile_id?: string | null
           status_order?: string | null
           user_id: string
           wasSuccess: boolean
@@ -50,12 +54,14 @@ export type Database = {
           collection_centre_id?: string | null
           content?: Json | null
           event_id?: string | null
+          family_member_id?: string | null
           list_hotel_id?: string | null
           list_id?: string | null
           log_id?: string | null
           packing_slot_id?: string | null
           parcel_id?: string | null
           primary_key?: string
+          profile_id?: string | null
           status_order?: string | null
           user_id?: string
           wasSuccess?: boolean
@@ -95,6 +101,13 @@ export type Database = {
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "events"
+            referencedColumns: ["primary_key"]
+          },
+          {
+            foreignKeyName: "audit_log_family_member_id_fkey"
+            columns: ["family_member_id"]
+            isOneToOne: false
+            referencedRelation: "families"
             referencedColumns: ["primary_key"]
           },
           {
@@ -140,11 +153,25 @@ export type Database = {
             referencedColumns: ["parcel_id"]
           },
           {
+            foreignKeyName: "audit_log_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["primary_key"]
+          },
+          {
             foreignKeyName: "audit_log_status_order_fkey"
             columns: ["status_order"]
             isOneToOne: false
             referencedRelation: "status_order"
             referencedColumns: ["event_name"]
+          },
+          {
+            foreignKeyName: "audit_log_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles_plus"
+            referencedColumns: ["user_id"]
           },
           {
             foreignKeyName: "audit_log_user_id_fkey"
@@ -598,6 +625,13 @@ export type Database = {
             foreignKeyName: "profiles_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: true
+            referencedRelation: "profiles_plus"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "profiles_primary_key_fkey"
+            columns: ["primary_key"]
+            isOneToOne: true
             referencedRelation: "users"
             referencedColumns: ["id"]
           },
@@ -683,6 +717,19 @@ export type Database = {
           packing_slot_order: number | null
           parcel_id: string | null
           voucher_number: string | null
+        }
+        Relationships: []
+      }
+      profiles_plus: {
+        Row: {
+          created_at: string | null
+          email: string | null
+          first_name: string | null
+          last_name: string | null
+          role: Database["public"]["Enums"]["role"] | null
+          telephone_number: string | null
+          updated_at: string | null
+          user_id: string | null
         }
         Relationships: []
       }

--- a/src/databaseTypesFile.ts
+++ b/src/databaseTypesFile.ts
@@ -16,7 +16,6 @@ export type Database = {
           collection_centre_id: string | null
           content: Json | null
           event_id: string | null
-          family_member_id: string | null
           list_hotel_id: string | null
           list_id: string | null
           log_id: string | null
@@ -35,7 +34,6 @@ export type Database = {
           collection_centre_id?: string | null
           content?: Json | null
           event_id?: string | null
-          family_member_id?: string | null
           list_hotel_id?: string | null
           list_id?: string | null
           log_id?: string | null
@@ -54,7 +52,6 @@ export type Database = {
           collection_centre_id?: string | null
           content?: Json | null
           event_id?: string | null
-          family_member_id?: string | null
           list_hotel_id?: string | null
           list_id?: string | null
           log_id?: string | null
@@ -101,13 +98,6 @@ export type Database = {
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "events"
-            referencedColumns: ["primary_key"]
-          },
-          {
-            foreignKeyName: "audit_log_family_member_id_fkey"
-            columns: ["family_member_id"]
-            isOneToOne: false
-            referencedRelation: "families"
             referencedColumns: ["primary_key"]
           },
           {
@@ -165,13 +155,6 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "status_order"
             referencedColumns: ["event_name"]
-          },
-          {
-            foreignKeyName: "audit_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles_plus"
-            referencedColumns: ["user_id"]
           },
           {
             foreignKeyName: "audit_log_user_id_fkey"
@@ -625,13 +608,6 @@ export type Database = {
             foreignKeyName: "profiles_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: true
-            referencedRelation: "profiles_plus"
-            referencedColumns: ["user_id"]
-          },
-          {
-            foreignKeyName: "profiles_primary_key_fkey"
-            columns: ["primary_key"]
-            isOneToOne: true
             referencedRelation: "users"
             referencedColumns: ["id"]
           },
@@ -717,19 +693,6 @@ export type Database = {
           packing_slot_order: number | null
           parcel_id: string | null
           voucher_number: string | null
-        }
-        Relationships: []
-      }
-      profiles_plus: {
-        Row: {
-          created_at: string | null
-          email: string | null
-          first_name: string | null
-          last_name: string | null
-          role: Database["public"]["Enums"]["role"] | null
-          telephone_number: string | null
-          updated_at: string | null
-          user_id: string | null
         }
         Relationships: []
       }

--- a/src/server/adminInviteUser.ts
+++ b/src/server/adminInviteUser.ts
@@ -111,7 +111,7 @@ export async function adminInviteUser(
             });
             return {
                 data: null,
-                error: { "Failed to create user profile": createRoleError.message },
+                error: { type: "createProfileFailure", logId: logId },
             };
         }
 

--- a/src/server/adminInviteUser.ts
+++ b/src/server/adminInviteUser.ts
@@ -50,7 +50,7 @@ export async function adminInviteUser(
     });
 
     const auditLog = {
-        action: "add a client",
+        action: "send invite link to user by email",
         content: {
             email: userDetails.email,
         },

--- a/src/server/adminInviteUser.ts
+++ b/src/server/adminInviteUser.ts
@@ -104,9 +104,12 @@ export async function adminInviteUser(
         } as const satisfies Partial<AuditLog>;
 
         if (createRoleError) {
-            const logId = await logErrorReturnLogId("failed to create profile for user", {
-                error: error,
-            });
+            const logId = await logErrorReturnLogId(
+                `failed to create profile for user with id ${newUserData.user.id}`,
+                {
+                    error: error,
+                }
+            );
             await sendAuditLog({
                 ...auditLogAddProfile,
                 wasSuccess: false,

--- a/src/server/adminInviteUser.ts
+++ b/src/server/adminInviteUser.ts
@@ -74,7 +74,7 @@ export async function adminInviteUser(
         wasSuccess: true,
         content: {
             ...auditLog.content,
-            userId: data.user.id,
+            newUserId: data.user.id,
             invitedAt: data.user.invited_at,
             createdAt: data.user.created_at,
         },

--- a/src/server/adminInviteUser.ts
+++ b/src/server/adminInviteUser.ts
@@ -49,7 +49,7 @@ export async function adminInviteUser(
         redirectTo: redirectUrl,
     });
 
-    const auditLog = {
+    const auditLogInviteUser = {
         action: "send invite link to user by email",
         content: {
             email: userDetails.email,
@@ -59,7 +59,7 @@ export async function adminInviteUser(
     if (error) {
         const logId = await logErrorReturnLogId("failed to invite user", { error: error });
         await sendAuditLog({
-            ...auditLog,
+            ...auditLogInviteUser,
             wasSuccess: false,
             logId,
         });
@@ -70,10 +70,10 @@ export async function adminInviteUser(
     }
 
     await sendAuditLog({
-        ...auditLog,
+        ...auditLogInviteUser,
         wasSuccess: true,
         content: {
-            ...auditLog.content,
+            ...auditLogInviteUser.content,
             newUserId: data.user.id,
             invitedAt: data.user.invited_at,
             createdAt: data.user.created_at,
@@ -93,7 +93,7 @@ export async function adminInviteUser(
             .select()
             .single();
 
-        const auditLog = {
+        const auditLogAddProfile = {
             action: "add a profile for user",
             content: {
                 email: userDetails.email,
@@ -105,7 +105,7 @@ export async function adminInviteUser(
                 error: error,
             });
             await sendAuditLog({
-                ...auditLog,
+                ...auditLogAddProfile,
                 wasSuccess: false,
                 logId,
             });
@@ -116,9 +116,9 @@ export async function adminInviteUser(
         }
 
         await sendAuditLog({
-            ...auditLog,
+            ...auditLogAddProfile,
             wasSuccess: true,
-            content: { ...auditLog.content, profile: profileData },
+            content: { ...auditLogAddProfile.content, profile: profileData },
             profileId: data.user.id,
         });
 

--- a/src/server/auditLog.ts
+++ b/src/server/auditLog.ts
@@ -20,6 +20,7 @@ export interface AuditLog {
     listHotelId?: string;
     packingSlotId?: string;
     parcelId?: string;
+    profileId?: string;
 }
 
 export async function sendAuditLog(auditLogProps: AuditLog): Promise<void> {
@@ -40,6 +41,7 @@ export async function sendAuditLog(auditLogProps: AuditLog): Promise<void> {
         list_hotel_id: auditLogProps.listHotelId,
         packing_slot_id: auditLogProps.packingSlotId,
         parcel_id: auditLogProps.parcelId,
+        profile_id: auditLogProps.profileId,
         content: auditLogProps.content,
         wasSuccess: auditLogProps.wasSuccess,
         log_id: auditLogProps.logId,

--- a/supabase/migrations/20240410114803_add_column_profile_id_to_audit_log_table.sql
+++ b/supabase/migrations/20240410114803_add_column_profile_id_to_audit_log_table.sql
@@ -1,0 +1,6 @@
+alter table "public"."audit_log" add column "profile_id" uuid;
+
+alter table "public"."audit_log" add constraint "audit_log_profile_id_fkey" FOREIGN KEY (profile_id) REFERENCES profiles(primary_key) not valid;
+
+alter table "public"."audit_log" validate constraint "audit_log_profile_id_fkey";
+


### PR DESCRIPTION
## What's changed
- Add audit logs for when email invite is sent and when profile for user is created
- Add profile_id to audit log for new user_id

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| paste_here | paste_here |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [x] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [x] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [x] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [x] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
