### PR TITLE
VFB-193: Add audit log for collection centre add, remove delete function

### DIFF
--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -75,8 +75,7 @@ const CollectionCentresTables: React.FC<Props> = (props) => {
             checkboxConfig={{ displayed: false }}
             sortConfig={{ sortPossible: false }}
             editableConfig={{
-                editable: true,
-                setDataPortion: setCollectionCentres,
+                editable: false,
             }}
             filterConfig={{
                 primaryFiltersShown: true,

--- a/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
+++ b/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
@@ -77,7 +77,9 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
             setSubmitErrorMessage(errorMessage);
             setSubmitDisabled(false);
 
-            const logId = await logErrorReturnLogId("Error with insert: collection centre", error);
+            const logId = await logErrorReturnLogId("Error with insert: collection centre", {
+                error: error,
+            });
             await sendAuditLog({ ...auditLog, wasSuccess: false, logId });
             throw new DatabaseError("insert", "collection centres", logId);
         }


### PR DESCRIPTION
## What's changed
- Remove delete function for collection centres
- Add audit log for when collection centre is added

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/c8487c2e-2401-4864-aca7-3744f5cb77e3) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/a83a959f-3309-4395-8354-9b7729942774) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... N/A
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
