### PR TITLE
VFB-193-fix: Display error message and logid instead of throw

### DIFF
--- a/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
+++ b/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
@@ -72,16 +72,15 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
         } as const satisfies Partial<AuditLog>;
 
         if (error) {
-            const errorMessage =
-                getCustomErrorMessage(error.code) ?? `${error.message}\n${Errors.external}`;
-            setSubmitErrorMessage(errorMessage);
-            setSubmitDisabled(false);
-
             const logId = await logErrorReturnLogId("Error with insert: collection centre", {
                 error: error,
             });
             await sendAuditLog({ ...auditLog, wasSuccess: false, logId });
-            throw new DatabaseError("insert", "collection centres", logId);
+            const errorMessage =
+                getCustomErrorMessage(error.code) ?? `${error.message}\n${Errors.external}`;
+            setSubmitErrorMessage(`Error: ${errorMessage} Log ID ${logId}`);
+            setSubmitDisabled(false);
+            return;
         }
 
         setSubmitErrorMessage("");

--- a/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
+++ b/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
@@ -18,7 +18,6 @@ import NameCard from "@/app/admin/createCollectionCentre/NameCard";
 import AcronymCard from "@/app/admin/createCollectionCentre/AcronymCard";
 import supabase from "@/supabaseClient";
 import { logErrorReturnLogId, logInfoReturnLogId } from "@/logger/logger";
-import { DatabaseError } from "@/app/errorClasses";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
 
 const initialFields: InsertSchema["collection_centres"] = {


### PR DESCRIPTION
## What's changed
- Display error message and log id
- Remove throw error

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| paste_here | paste_here |

## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [ ] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
