### PR TITLE
VFB-194 VFB-195: Add audit logs for adding and editing packing slots and fix RLS policies checking for admin access

### DIFF
--- a/.snaplet/snaplet-client.d.ts
+++ b/.snaplet/snaplet-client.d.ts
@@ -155,6 +155,7 @@ type Override = {
       created_at?: string;
       updated_at?: string;
       authentication_method?: string;
+      auth_code_issued_at?: string;
       saml_relay_states?: string;
     };
   }
@@ -421,6 +422,7 @@ type Override = {
       attribute_mapping?: string;
       created_at?: string;
       updated_at?: string;
+      name_id_format?: string;
       sso_providers?: string;
     };
   }
@@ -432,7 +434,6 @@ type Override = {
       request_id?: string;
       for_email?: string;
       redirect_to?: string;
-      from_ip_address?: string;
       created_at?: string;
       updated_at?: string;
       flow_state_id?: string;
@@ -555,6 +556,7 @@ type Override = {
       reauthentication_sent_at?: string;
       is_sso_user?: string;
       deleted_at?: string;
+      is_anonymous?: string;
       identities?: string;
       mfa_factors?: string;
       sessions?: string;
@@ -643,6 +645,7 @@ export interface Fingerprint {
   flowStates?: {
     createdAt?: FingerprintDateField;
     updatedAt?: FingerprintDateField;
+    authCodeIssuedAt?: FingerprintDateField;
     samlRelayStates?: FingerprintRelationField;
   }
   hooks?: {

--- a/.snaplet/snaplet-client.d.ts
+++ b/.snaplet/snaplet-client.d.ts
@@ -45,6 +45,7 @@ type Override = {
       content?: string;
       wasSuccess?: string;
       log_id?: string;
+      profile_id?: string;
       users?: string;
       clients?: string;
       collection_centres?: string;
@@ -53,6 +54,7 @@ type Override = {
       lists_hotel?: string;
       packing_slots?: string;
       parcels?: string;
+      profiles?: string;
       status_order?: string;
       website_data?: string;
     };
@@ -611,6 +613,7 @@ export interface Fingerprint {
     listsHotelByListHotelId?: FingerprintRelationField;
     packingSlotByPackingSlotId?: FingerprintRelationField;
     parcelByParcelId?: FingerprintRelationField;
+    profileByProfileId?: FingerprintRelationField;
     statusOrderByStatusOrder?: FingerprintRelationField;
     websiteDatumByWebsiteData?: FingerprintRelationField;
   }
@@ -731,7 +734,7 @@ export interface Fingerprint {
     eventsByParcelId?: FingerprintRelationField;
   }
   profiles?: {
-    userByPrimaryKey?: FingerprintRelationField;
+    user?: FingerprintRelationField;
     auditLogsByProfileId?: FingerprintRelationField;
   }
   refreshTokens?: {
@@ -810,7 +813,7 @@ export interface Fingerprint {
     mfaFactors?: FingerprintRelationField;
     sessions?: FingerprintRelationField;
     auditLogs?: FingerprintRelationField;
-    profilesByPrimaryKey?: FingerprintRelationField;
+    profiles?: FingerprintRelationField;
   }
   websiteData?: {
     auditLogsByWebsiteData?: FingerprintRelationField;

--- a/.snaplet/snaplet.d.ts
+++ b/.snaplet/snaplet.d.ts
@@ -37,8 +37,8 @@ interface Table_public_audit_log {
   content: Json | null;
   wasSuccess: boolean;
   log_id: string | null;
-}
   profile_id: string | null;
+}
 interface Table_auth_audit_log_entries {
   instance_id: string | null;
   id: string;
@@ -506,8 +506,8 @@ interface Tables_relationships {
        audit_log_list_hotel_id_fkey: "public.lists_hotel";
        audit_log_packing_slot_id_fkey: "public.packing_slots";
        audit_log_parcel_id_fkey: "public.parcels";
-       audit_log_status_order_fkey: "public.status_order";
        audit_log_profile_id_fkey: "public.profiles";
+       audit_log_status_order_fkey: "public.status_order";
        audit_log_website_data_fkey: "public.website_data";
     };
     children: {

--- a/.snaplet/snaplet.d.ts
+++ b/.snaplet/snaplet.d.ts
@@ -108,6 +108,7 @@ interface Table_auth_flow_state {
   created_at: string | null;
   updated_at: string | null;
   authentication_method: string;
+  auth_code_issued_at: string | null;
 }
 interface Table_supabase_functions_hooks {
   id: number;
@@ -296,6 +297,7 @@ interface Table_auth_saml_providers {
   attribute_mapping: Json | null;
   created_at: string | null;
   updated_at: string | null;
+  name_id_format: string | null;
 }
 interface Table_auth_saml_relay_states {
   id: string;
@@ -303,7 +305,6 @@ interface Table_auth_saml_relay_states {
   request_id: string;
   for_email: string | null;
   redirect_to: string | null;
-  from_ip_address: string | null;
   created_at: string | null;
   updated_at: string | null;
   flow_state_id: string | null;
@@ -390,6 +391,7 @@ interface Table_auth_users {
   reauthentication_sent_at: string | null;
   is_sso_user: boolean;
   deleted_at: string | null;
+  is_anonymous: boolean;
 }
 interface Table_public_website_data {
   name: string;

--- a/README.md
+++ b/README.md
@@ -151,3 +151,4 @@ You can regenerate the types
 - [Release Instructions](./docs/release.md)
 - [Common Problems](./docs/common-problems.md)
 - [Design Choices](./docs/design-choices.md)
+- [E2E Testing](./docs/e2e-testing.md)

--- a/cypress/e2e/admin/packingSlots.cy.ts
+++ b/cypress/e2e/admin/packingSlots.cy.ts
@@ -1,5 +1,3 @@
-import Chainable = Cypress.Chainable;
-
 const modifyPackingSlotsText = "modify packing slots";
 
 describe("Packing slots on admins page", () => {

--- a/cypress/e2e/admin/packingSlots.cy.ts
+++ b/cypress/e2e/admin/packingSlots.cy.ts
@@ -1,0 +1,56 @@
+import Chainable = Cypress.Chainable;
+
+const modifyPackingSlotsText = "modify packing slots";
+
+describe("Packing slots on admins page", () => {
+    it("Move the first packing slot down and then up", () => {
+        cy.login();
+
+        cy.visit("/admin");
+
+        cy.contains(modifyPackingSlotsText, { matchCase: false }).click();
+
+        assertPackingSlotName({ rowIndex: 0, packingSlotName: "AM" });
+        assertPackingSlotName({ rowIndex: 1, packingSlotName: "PM" });
+
+        movePackingSlot({ rowIndex: 0, direction: "down" });
+
+        assertPackingSlotName({ rowIndex: 0, packingSlotName: "PM" });
+        assertPackingSlotName({ rowIndex: 1, packingSlotName: "AM" });
+
+        movePackingSlot({ rowIndex: 1, direction: "up" });
+
+        assertPackingSlotName({ rowIndex: 0, packingSlotName: "AM" });
+        assertPackingSlotName({ rowIndex: 1, packingSlotName: "PM" });
+    });
+});
+
+function movePackingSlot({
+    rowIndex,
+    direction,
+}: {
+    rowIndex: number;
+    direction: "up" | "down";
+}): void {
+    cy.contains(modifyPackingSlotsText, { matchCase: false })
+        .parents(".MuiPaper-root")
+        .find(`[data-rowindex="${rowIndex}"]`) // eslint-disable-line quotes
+        .find(`[data-testid="${direction === "up" ? "ArrowCircleUpIcon" : "ArrowCircleDownIcon"}"]`) // eslint-disable-line quotes
+        .click();
+}
+
+function assertPackingSlotName({
+    rowIndex,
+    packingSlotName,
+}: {
+    rowIndex: number;
+    packingSlotName: string;
+}): void {
+    cy.contains(modifyPackingSlotsText, { matchCase: false })
+        .parents(".MuiPaper-root")
+        .find(`[data-rowindex="${rowIndex}"]`) // eslint-disable-line quotes
+        .find('[data-field="name"]') // eslint-disable-line quotes
+        .should(($slotName) => {
+            expect($slotName).to.contain(packingSlotName);
+        });
+}

--- a/cypress/e2e/admin/packingSlots.cy.ts
+++ b/cypress/e2e/admin/packingSlots.cy.ts
@@ -1,12 +1,11 @@
-const modifyPackingSlotsText = "modify packing slots";
-
 describe("Packing slots on admins page", () => {
-    it("Move the first packing slot down and then up", () => {
+    beforeEach(() => {
         cy.login();
-
         cy.visit("/admin");
+    });
 
-        cy.contains(modifyPackingSlotsText, { matchCase: false }).click();
+    it("Move the first packing slot down and then up", () => {
+        togglePackingSlotsSection();
 
         assertPackingSlotName({ rowIndex: 0, packingSlotName: "AM" });
         assertPackingSlotName({ rowIndex: 1, packingSlotName: "PM" });
@@ -22,6 +21,12 @@ describe("Packing slots on admins page", () => {
         assertPackingSlotName({ rowIndex: 1, packingSlotName: "PM" });
     });
 });
+
+const modifyPackingSlotsText = "modify packing slots";
+
+function togglePackingSlotsSection(): void {
+    cy.contains(modifyPackingSlotsText, { matchCase: false }).click();
+}
 
 function movePackingSlot({
     rowIndex,

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,5 +1,6 @@
 # E2E Testing
 
+## How to run tests
 - Run `npm run dev -- -p 3200` to run the dev server on port 3200, where Cypress will run the tests on
 - Use `npx cypress open` to open Cypress client to run specific tests and allow hot-reloads.
 - You can also do `npm run build` and then `npm run test:e2e --spec=<your_test_file_path>` to run tests in the specific file

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,5 @@
+# E2E Testing
+
+- Run `npm run dev -- -p 3200` to run the dev server on port 3200, where Cypress will run the tests on
+- Use `npx cypress open` to open Cypress client to run specific tests and allow hot-reloads.
+- You can also do `npm run build` and then `npm run test:e2e --spec=<your_test_file_path>` to run tests in the specific file

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "open:cypress": "start-server-and-test 'next start -p 3100' http://localhost:3100 'npx cypress open --config baseUrl=http://localhost:3100'",
     "test": "start-server-and-test test:runner_server_release http://localhost:3200 test:runner",
     "test:component": "start-server-and-test test:runner_server_release http://localhost:3200 test:runner_component",
-    "test:e2e": "start-server-and-test test:runner_server_release http://localhost:3200 test:runner_e2e",
+    "test:e2e": "start-server-and-test test:runner_server_release http://localhost:3200 \"npm run test:runner_e2e -- --spec '${npm_config_spec}'\"",
     "test:coverage": "npm run coverage:generate && npm run coverage:run_tests && npm run coverage:report",
     "test:runner": "npm run test:runner_component && npm run test:runner_e2e",
     "test:runner_component": "npx cypress run --component",

--- a/src/app/admin/packingSlotsTable/PackingSlotActions.ts
+++ b/src/app/admin/packingSlotsTable/PackingSlotActions.ts
@@ -60,7 +60,11 @@ export const insertNewPackingSlot = async (
     newRow: PackingSlotRow
 ): Promise<InsertPackingSlotResult> => {
     const data = formatNewRowToDBPackingSlot(newRow);
-    const { data: packingSlot, error } = await supabase.from("packing_slots").insert(data).select().single();
+    const { data: packingSlot, error } = await supabase
+        .from("packing_slots")
+        .insert(data)
+        .select()
+        .single();
 
     if (error) {
         const logId = await logErrorReturnLogId("Failed to add a packing slot", {

--- a/src/app/admin/packingSlotsTable/PackingSlotActions.ts
+++ b/src/app/admin/packingSlotsTable/PackingSlotActions.ts
@@ -57,7 +57,7 @@ export const insertNewPackingSlot = async (
     const { error } = await supabase.from("packing_slots").insert(data);
 
     if (error) {
-        const logId = await logErrorReturnLogId("Error with insert: Packing slots", {
+        const logId = await logErrorReturnLogId("Failed to add a packing slot", {
             error,
             newPackingSlotData: data,
         });
@@ -100,6 +100,8 @@ export const swapRows = async (
     if (error) {
         const logId = await logErrorReturnLogId("Failed to update packing slot order", {
             error,
+            packingSlot1: row1,
+            packingSlot2: row2,
         });
         return { error: { dbError: error, logId } };
     }

--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -165,13 +165,13 @@ const PackingSlotsTable: React.FC = () => {
                 setErrorMessage(
                     `Failed to add the packing slot. Log ID: ${insertPackingSlotError.logId}`
                 );
-                await sendAuditLog({
+                void sendAuditLog({
                     ...baseAuditLog,
                     wasSuccess: false,
                     logId: insertPackingSlotError.logId,
                 });
             } else {
-                await sendAuditLog({
+                void sendAuditLog({
                     ...baseAuditLog,
                     packingSlotId: createdPackingSlot.packingSlotId,
                     wasSuccess: true,
@@ -188,17 +188,18 @@ const PackingSlotsTable: React.FC = () => {
                 setErrorMessage(
                     `Failed to update the packing slot. Log ID: ${updatePackingSlotError.logId}`
                 );
-                await sendAuditLog({
+                void sendAuditLog({
                     ...baseAuditLog,
                     wasSuccess: false,
                     logId: updatePackingSlotError.logId,
                 });
             } else {
-                await sendAuditLog({ ...baseAuditLog, wasSuccess: true });
+                void sendAuditLog({ ...baseAuditLog, wasSuccess: true });
             }
         }
 
         setIsLoading(false);
+
         return newRow;
     };
 

--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -82,7 +82,7 @@ function getBaseAuditLogForPackingSlotAction(
     return {
         action,
         content: {
-            originalOrder: packingSlotRow.order,
+            currentPackingSlotOrder: packingSlotRow.order,
             packingSlotName: packingSlotRow.name,
             packingSlotIsShown: packingSlotRow.isShown,
         },

--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -144,24 +144,29 @@ const PackingSlotsTable: React.FC = () => {
         }));
     };
 
-    const processRowUpdate = (newRow: PackingSlotRow): PackingSlotRow => {
+    const processRowUpdate = async (newRow: PackingSlotRow): Promise<PackingSlotRow> => {
         setErrorMessage(null);
         setIsLoading(true);
+
         if (newRow.isNew) {
-            insertNewPackingSlot(newRow)
-                .catch((error) => {
-                    void logErrorReturnLogId("Insert error with packing slot row", error);
-                    setErrorMessage("Error inserting data, please try again");
-                })
-                .finally(() => setIsLoading(false));
+            const { error: insertPackingSlotError } = await insertNewPackingSlot(newRow);
+
+            if (insertPackingSlotError) {
+                setErrorMessage(
+                    `Failed to add the packing slot. Log ID: ${insertPackingSlotError.logId}`
+                );
+            }
         } else {
-            updateDbPackingSlot(newRow)
-                .catch((error) => {
-                    void logErrorReturnLogId("Update error with packing slot row", error);
-                    setErrorMessage("Error updating data, please try again");
-                })
-                .finally(() => setIsLoading(false));
+            const { error: updatePackingSlotError } = await updateDbPackingSlot(newRow);
+
+            if (updatePackingSlotError) {
+                setErrorMessage(
+                    `Failed to update the packing slot. Log ID: ${updatePackingSlotError.logId}`
+                );
+            }
         }
+
+        setIsLoading(false);
         return newRow;
     };
 

--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -278,7 +278,7 @@ const PackingSlotsTable: React.FC = () => {
 
             if (swapRowsError) {
                 setErrorMessage(
-                    `Failed to move packing slot (${row.name}) up. Log ID: ${swapRowsError.logId}`
+                    `Failed to move packing slot (${row.name}) down. Log ID: ${swapRowsError.logId}`
                 );
                 void sendAuditLog({ ...baseAuditLog, wasSuccess: false });
             } else {

--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -280,7 +280,11 @@ const PackingSlotsTable: React.FC = () => {
                 setErrorMessage(
                     `Failed to move packing slot (${row.name}) down. Log ID: ${swapRowsError.logId}`
                 );
-                void sendAuditLog({ ...baseAuditLog, wasSuccess: false });
+                void sendAuditLog({
+                    ...baseAuditLog,
+                    wasSuccess: false,
+                    logId: swapRowsError.logId,
+                });
             } else {
                 void sendAuditLog({ ...baseAuditLog, wasSuccess: true });
             }

--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -153,7 +153,8 @@ const PackingSlotsTable: React.FC = () => {
         setIsLoading(true);
 
         if (newRow.isNew) {
-            const { error: insertPackingSlotError } = await insertNewPackingSlot(newRow);
+            const { data: createdPackingSlot, error: insertPackingSlotError } =
+                await insertNewPackingSlot(newRow);
             const baseAuditLog = getBaseAuditLogForPackingSlotAction(
                 "add a new packing slot",
                 newRow,
@@ -170,7 +171,11 @@ const PackingSlotsTable: React.FC = () => {
                     logId: insertPackingSlotError.logId,
                 });
             } else {
-                await sendAuditLog({ ...baseAuditLog, wasSuccess: true });
+                await sendAuditLog({
+                    ...baseAuditLog,
+                    packingSlotId: createdPackingSlot.packingSlotId,
+                    wasSuccess: true,
+                });
             }
         } else {
             const { error: updatePackingSlotError } = await updateDbPackingSlot(newRow);

--- a/src/databaseTypesFile.ts
+++ b/src/databaseTypesFile.ts
@@ -720,6 +720,10 @@ export type Database = {
         }
         Returns: string
       }
+      user_is_admin: {
+        Args: Record<PropertyKey, never>
+        Returns: boolean
+      }
     }
     Enums: {
       gender: "male" | "female" | "other"

--- a/supabase/migrations/20240411144335_fix_admin_only_rls_policies.sql
+++ b/supabase/migrations/20240411144335_fix_admin_only_rls_policies.sql
@@ -1,0 +1,73 @@
+drop policy "Enable access for admin user, select for authenticated" on "public"."collection_centres";
+
+drop policy "Enable access for admin user, select for authenticated" on "public"."lists";
+
+drop policy "Enable access for admin user, select for authenticated" on "public"."lists_hotel";
+
+drop policy "Enable access to admins, select for authenticated" on "public"."packing_slots";
+
+drop policy "Enable access for admin user, select for authenticated" on "public"."website_data";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.user_is_admin()
+ RETURNS boolean
+ LANGUAGE plpgsql
+AS $function$BEGIN
+RETURN EXISTS ( 
+  SELECT 1
+  FROM profiles
+  WHERE (
+    (profiles.user_id = auth.uid()) AND 
+    (profiles.role = 'admin'::role)
+  )
+);
+END;$function$
+;
+
+create policy "Enable access for admin user, select for authenticated"
+on "public"."collection_centres"
+as permissive
+for all
+to authenticated
+using (true)
+with check (user_is_admin());
+
+
+create policy "Enable access for admin user, select for authenticated"
+on "public"."lists"
+as permissive
+for all
+to authenticated
+using (true)
+with check (user_is_admin());
+
+
+create policy "Enable access for admin user, select for authenticated"
+on "public"."lists_hotel"
+as permissive
+for all
+to authenticated
+using (true)
+with check (user_is_admin());
+
+
+create policy "Enable access to admins, select for authenticated"
+on "public"."packing_slots"
+as permissive
+for all
+to authenticated
+using (true)
+with check (user_is_admin());
+
+
+create policy "Enable access for admin user, select for authenticated"
+on "public"."website_data"
+as permissive
+for all
+to authenticated
+using (true)
+with check (user_is_admin());
+
+
+


### PR DESCRIPTION
## What's changed
- Add audit logs for adding and editing packing slots
- Fix RLS policies checking for admin access
- Add an e2e test for moving packing slots

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [x] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [x] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [x] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [x] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
