### PR TITLE
VFB-196 Add audit logs when website data is edited

### DIFF
--- a/src/app/admin/websiteDataTable/WebsiteDataTable.tsx
+++ b/src/app/admin/websiteDataTable/WebsiteDataTable.tsx
@@ -40,6 +40,7 @@ const WebsiteDataTable: React.FC = () => {
     const dataGridRef = useGridApiRef();
 
     const fetchAndSetWebsiteData = useCallback(async () => {
+        setIsLoading(true);
         setErrorMessage(null);
         const { data: websiteData, error: websiteDataError } = await fetchWebsiteData();
         if (websiteDataError) {
@@ -52,7 +53,6 @@ const WebsiteDataTable: React.FC = () => {
     }, []);
 
     useEffect(() => {
-        setIsLoading(true);
         void fetchAndSetWebsiteData();
     }, [fetchAndSetWebsiteData]);
 

--- a/src/app/admin/websiteDataTable/WebsiteDataTable.tsx
+++ b/src/app/admin/websiteDataTable/WebsiteDataTable.tsx
@@ -45,7 +45,13 @@ const WebsiteDataTable: React.FC = () => {
         const { data: websiteData, error: websiteDataError } = await fetchWebsiteData();
         if (websiteDataError) {
             setRows([]);
-            setErrorMessage(`${websiteDataError.type}. Log ID: ${websiteDataError.logId}`);
+            switch (websiteDataError.type) {
+                case "failedToFetchWebsiteData":
+                    setErrorMessage(
+                        `Failed to retrieve website data. Log ID ${websiteDataError.logId}`
+                    );
+                    break;
+            }
         } else {
             setRows(websiteData);
         }
@@ -88,7 +94,11 @@ const WebsiteDataTable: React.FC = () => {
         const { error } = await updateDbWebsiteData(newRow);
 
         if (error) {
-            setErrorMessage(`${error.type}. Log ID: ${error.logId}`);
+            switch (error.type) {
+                case "failedToUpdateWebsiteData":
+                    setErrorMessage(`Failed to update website data. Log ID ${error.logId}`);
+                    break;
+            }
         }
 
         setIsLoading(false);

--- a/src/app/admin/websiteDataTable/fetchWebsiteData.ts
+++ b/src/app/admin/websiteDataTable/fetchWebsiteData.ts
@@ -56,10 +56,12 @@ export const updateDbWebsiteData = async (
         value: row.value,
     };
 
-    const { error } = await supabase
+    const { data: updateWebsiteData, error } = await supabase
         .from("website_data")
         .update(processedData)
-        .eq("name", processedData.name);
+        .eq("name", processedData.name)
+        .select()
+        .single();
 
     const auditLog = {
         action: "update website data",
@@ -72,6 +74,6 @@ export const updateDbWebsiteData = async (
         void sendAuditLog({ ...auditLog, wasSuccess: false, logId });
         return { error: { type: "Failed to update website data", logId } };
     }
-    void sendAuditLog({ ...auditLog, wasSuccess: true });
+    void sendAuditLog({ ...auditLog, wasSuccess: true, content: updateWebsiteData });
     return { error: null };
 };

--- a/src/app/admin/websiteDataTable/fetchWebsiteData.ts
+++ b/src/app/admin/websiteDataTable/fetchWebsiteData.ts
@@ -5,7 +5,7 @@ import { logErrorReturnLogId } from "@/logger/logger";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
 
 type DbWebsiteData = Tables<"website_data">;
-type FetchWebsiteDataErrors = "Failed to fetch website data";
+type FetchWebsiteDataErrors = "failedToFetchWebsiteData";
 type FetchWebsiteDataErrorReturn =
     | {
           data: null;
@@ -15,7 +15,7 @@ type FetchWebsiteDataErrorReturn =
           data: WebsiteDataRow[];
           error: null;
       };
-type UpdateWebsiteDataErrors = "Failed to update website data";
+type UpdateWebsiteDataErrors = "failedToUpdateWebsiteData";
 type UpdateWebsiteDataErrorReturn =
     | {
           error: { type: UpdateWebsiteDataErrors; logId: string };
@@ -33,7 +33,7 @@ export const fetchWebsiteData = async (): Promise<FetchWebsiteDataErrorReturn> =
 
     if (error) {
         const logId = await logErrorReturnLogId("Error with fetch: website data", error);
-        return { error: { type: "Failed to fetch website data", logId }, data: null };
+        return { error: { type: "failedToFetchWebsiteData", logId }, data: null };
     }
 
     const websiteData = data.map(
@@ -56,7 +56,7 @@ export const updateDbWebsiteData = async (
         value: row.value,
     };
 
-    const { data: updateWebsiteData, error } = await supabase
+    const { data: updatedWebsiteData, error } = await supabase
         .from("website_data")
         .update(processedData)
         .eq("name", processedData.name)
@@ -72,8 +72,8 @@ export const updateDbWebsiteData = async (
     if (error) {
         const logId = await logErrorReturnLogId("Error with update: website data", error);
         void sendAuditLog({ ...auditLog, wasSuccess: false, logId });
-        return { error: { type: "Failed to update website data", logId } };
+        return { error: { type: "failedToUpdateWebsiteData", logId } };
     }
-    void sendAuditLog({ ...auditLog, wasSuccess: true, content: updateWebsiteData });
+    void sendAuditLog({ ...auditLog, wasSuccess: true, content: updatedWebsiteData });
     return { error: null };
 };

--- a/src/app/admin/websiteDataTable/fetchWebsiteData.ts
+++ b/src/app/admin/websiteDataTable/fetchWebsiteData.ts
@@ -1,10 +1,26 @@
 import supabase from "@/supabaseClient";
-import { DatabaseError } from "@/app/errorClasses";
 import { WebsiteDataRow } from "./WebsiteDataTable";
 import { Tables } from "@/databaseTypesFile";
 import { logErrorReturnLogId } from "@/logger/logger";
+import { AuditLog, sendAuditLog } from "@/server/auditLog";
 
 type DbWebsiteData = Tables<"website_data">;
+type FetchWebsiteDataErrors = "Failed to fetch website data";
+type FetchWebsiteDataErrorReturn =
+    | {
+          data: null;
+          error: { type: FetchWebsiteDataErrors; logId: string };
+      }
+    | {
+          data: WebsiteDataRow[];
+          error: null;
+      };
+type UpdateWebsiteDataErrors = "Failed to update website data";
+type UpdateWebsiteDataErrorReturn =
+    | {
+          error: { type: UpdateWebsiteDataErrors; logId: string };
+      }
+    | { error: null };
 
 const getReadableName = (name: string): string =>
     name
@@ -12,14 +28,15 @@ const getReadableName = (name: string): string =>
         .map((word) => `${word[0].toUpperCase()}${word.slice(1)}`)
         .join(" ");
 
-export const fetchWebsiteData = async (): Promise<WebsiteDataRow[]> => {
+export const fetchWebsiteData = async (): Promise<FetchWebsiteDataErrorReturn> => {
     const { data, error } = await supabase.from("website_data").select().order("name");
+
     if (error) {
         const logId = await logErrorReturnLogId("Error with fetch: website data", error);
-        throw new DatabaseError("fetch", "website data table", logId);
+        return { error: { type: "Failed to fetch website data", logId }, data: null };
     }
 
-    return data.map(
+    const websiteData = data.map(
         (row): WebsiteDataRow => ({
             dbName: row.name,
             readableName: getReadableName(row.name),
@@ -27,20 +44,34 @@ export const fetchWebsiteData = async (): Promise<WebsiteDataRow[]> => {
             id: row.name,
         })
     );
+
+    return { data: websiteData, error: null };
 };
 
-export const updateDbWebsiteData = async (row: WebsiteDataRow): Promise<void> => {
+export const updateDbWebsiteData = async (
+    row: WebsiteDataRow
+): Promise<UpdateWebsiteDataErrorReturn> => {
     const processedData: DbWebsiteData = {
         name: row.dbName,
         value: row.value,
     };
+
     const { error } = await supabase
         .from("website_data")
         .update(processedData)
         .eq("name", processedData.name);
 
+    const auditLog = {
+        action: "update website data",
+        content: processedData,
+        websiteData: processedData.name,
+    } as const satisfies Partial<AuditLog>;
+
     if (error) {
         const logId = await logErrorReturnLogId("Error with update: website data", error);
-        throw new DatabaseError("update", "website data table", logId);
+        void sendAuditLog({ ...auditLog, wasSuccess: false, logId });
+        return { error: { type: "Failed to update website data", logId } };
     }
+    void sendAuditLog({ ...auditLog, wasSuccess: true });
+    return { error: null };
 };

--- a/src/server/auditLog.ts
+++ b/src/server/auditLog.ts
@@ -21,6 +21,7 @@ export interface AuditLog {
     packingSlotId?: string;
     parcelId?: string;
     profileId?: string;
+    websiteData?: string;
 }
 
 export async function sendAuditLog(auditLogProps: AuditLog): Promise<void> {
@@ -45,6 +46,7 @@ export async function sendAuditLog(auditLogProps: AuditLog): Promise<void> {
         content: auditLogProps.content,
         wasSuccess: auditLogProps.wasSuccess,
         log_id: auditLogProps.logId,
+        website_data: auditLogProps.websiteData,
     };
 
     const supabase = getSupabaseServerComponentClient();


### PR DESCRIPTION
## What's changed
- Add audit log when website data is updated
- Return error instead of throwing
- Handling error and display error message to user

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| paste_here | paste_here |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... N/A
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
