### PR TITLE
VFB-199: Fixed bug where parcels were added one day before their packing date

### DIFF
--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -41,6 +41,7 @@ import { ContentDiv, OutsideDiv } from "@/components/Modal/ModalFormStyles";
 import DataViewer from "@/components/DataViewer/DataViewer";
 import { useTheme } from "styled-components";
 import PackingSlotsCard from "@/app/parcels/form/formSections/PackingSlotsCard";
+import { getDbDate } from "@/common/format";
 
 export interface ParcelFields extends Fields {
     clientId: string | null;
@@ -183,14 +184,13 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
             return;
         }
 
-        const packingDate = dayjs(fields.packingDate).toISOString();
+        const packingDate = getDbDate(dayjs(fields.packingDate));
 
         let collectionDateTime = null;
         if (fields.shippingMethod === "Collection") {
-            collectionDateTime = mergeDateAndTime(
-                fields.collectionDate!,
-                fields.collectionTime!
-            ).toISOString();
+            collectionDateTime = getDbDate(
+                mergeDateAndTime(fields.collectionDate!, fields.collectionTime!)
+            );
         }
 
         const isDelivery = fields.shippingMethod === "Delivery";

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -188,9 +188,10 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
 
         let collectionDateTime = null;
         if (fields.shippingMethod === "Collection") {
-            collectionDateTime = getDbDate(
-                mergeDateAndTime(fields.collectionDate!, fields.collectionTime!)
-            );
+            collectionDateTime = mergeDateAndTime(
+                fields.collectionDate!,
+                fields.collectionTime!
+            ).toISOString();
         }
 
         const isDelivery = fields.shippingMethod === "Delivery";


### PR DESCRIPTION
## What's changed
Fixed a bug where any new parcels were added with a date equal to the day before the packing date that was input by the user.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test:e2e`

No DB changes.
