### PR TITLE
VFB-200: Add subscription channel to collections centre table

### DIFF
--- a/src/app/admin/AdminPage.tsx
+++ b/src/app/admin/AdminPage.tsx
@@ -19,7 +19,6 @@ import {
 import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import CollectionCentresTable from "@/app/admin/collectionCentresTable/CollectionCentresTable";
-import { Schema } from "@/databaseUtils";
 import CreateCollectionCentreForm from "@/app/admin/createCollectionCentre/CreateCollectionCentreForm";
 import PackingSlotsTable from "@/app/admin/packingSlotsTable/PackingSlotsTable";
 import WebsiteDataTable from "./websiteDataTable/WebsiteDataTable";
@@ -34,15 +33,11 @@ interface Panel {
     panelContent: ReactElement;
 }
 
-interface Props {
-    collectionCentreData: Schema["collection_centres"][];
-}
-
 const PanelIcon = styled(FontAwesomeIcon)`
     padding-right: 0.9rem;
 `;
 
-const AdminPage: React.FC<Props> = (props) => {
+const AdminPage: React.FC = () => {
     const adminPanels: Panel[] = [
         {
             panelTitle: "Users Table",
@@ -53,9 +48,7 @@ const AdminPage: React.FC<Props> = (props) => {
         {
             panelTitle: "Collection Centres Table",
             panelIcon: faCity,
-            panelContent: (
-                <CollectionCentresTable collectionCentreData={props.collectionCentreData} />
-            ),
+            panelContent: <CollectionCentresTable />,
         },
         {
             panelTitle: "Create Collection Centre",

--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -6,7 +6,6 @@ import styled from "styled-components";
 import { Schema } from "@/databaseUtils";
 import { Filter, PaginationType } from "@/components/Tables/Filters";
 import { buildTextFilter, filterRowByText } from "@/components/Tables/TextFilter";
-import { getSupabaseServerComponentClient } from "@/supabaseServer";
 import { logErrorReturnLogId } from "@/logger/logger";
 import supabase from "@/supabaseClient";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
@@ -46,11 +45,7 @@ const filters: Filter<CollectionCentresTableRow, string>[] = [
     }),
 ];
 
-interface Props {
-    collectionCentreData: CollectionCentresTableRow[];
-}
-
-const CollectionCentresTables: React.FC<Props> = (props) => {
+const CollectionCentresTables: React.FC = () => {
     const [collectionCentres, setCollectionCentres] = useState<Schema["collection_centres"][]>([]);
     const [primaryFilters, setPrimaryFilters] =
         useState<Filter<CollectionCentresTableRow, string>[]>(filters);
@@ -69,19 +64,6 @@ const CollectionCentresTables: React.FC<Props> = (props) => {
 
         setCollectionCentres(data);
     }, []);
-
-    useEffect(() => {
-        setCollectionCentres(
-            props.collectionCentreData.filter((row) => {
-                return primaryFilters.every((filter) => {
-                    return (
-                        filter.methodConfig.paginationType === PaginationType.Client &&
-                        filter.methodConfig.method(row, filter.state, filter.key)
-                    );
-                });
-            })
-        );
-    }, [primaryFilters, props.collectionCentreData]);
 
     useEffect(() => {
         void fetchAndDisplayCollectionCentres();

--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -70,7 +70,6 @@ const CollectionCentresTables: React.FC = () => {
     }, [fetchAndDisplayCollectionCentres]);
 
     useEffect(() => {
-        void fetchAndDisplayCollectionCentres();
         const subscriptionChannel = supabase
             .channel("collection-centres-table-changes")
             .on(

--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -71,7 +71,6 @@ const CollectionCentresTables: React.FC = () => {
 
     useEffect(() => {
         void fetchAndDisplayCollectionCentres();
-        // This requires that the DB clients, collection_centres, and families tables have Realtime turned on
         const subscriptionChannel = supabase
             .channel("collection-centres-table-changes")
             .on(

--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -87,7 +87,7 @@ const CollectionCentresTables: React.FC = () => {
         return () => {
             void supabase.removeChannel(subscriptionChannel);
         };
-    }, [fetchAndDisplayCollectionCentres, primaryFilters]);
+    }, [fetchAndDisplayCollectionCentres]);
 
     return (
         <>

--- a/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
+++ b/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
@@ -47,7 +47,6 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
     const [submitErrorMessage, setSubmitErrorMessage] = useState("");
     const [submitDisabled, setSubmitDisabled] = useState(false);
 
-    const [addCollectionCentreIsSuccess, setAddCollectionCentreIsSuccess] = useState(false);
     const [newCollectionCentre, setNewCollectionCentre] = useState<string | null>(null);
 
     const fieldSetter = setField(setFields, fields);
@@ -55,7 +54,6 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
 
     const submitForm = async (): Promise<void> => {
         setSubmitDisabled(true);
-        setAddCollectionCentreIsSuccess(false);
 
         if (checkErrorOnSubmit(formErrors, setFormErrors)) {
             setSubmitDisabled(false);
@@ -90,7 +88,6 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
         await sendAuditLog({ ...auditLog, wasSuccess: true, collectionCentreId: data.primary_key });
         void logInfoReturnLogId(`Collection centre: ${data.name} has been created successfully.`);
         setNewCollectionCentre(data.name);
-        setAddCollectionCentreIsSuccess(true);
     };
 
     return (
@@ -106,7 +103,7 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
                     />
                 ))}
 
-                {addCollectionCentreIsSuccess ? (
+                {newCollectionCentre ? (
                     <Alert severity="success" action={<RefreshPageButton />}>
                         Collection centre <b>{newCollectionCentre}</b> added successfully.
                     </Alert>

--- a/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
+++ b/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
@@ -19,6 +19,7 @@ import AcronymCard from "@/app/admin/createCollectionCentre/AcronymCard";
 import supabase from "@/supabaseClient";
 import { logErrorReturnLogId, logInfoReturnLogId } from "@/logger/logger";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
+import Alert from "@mui/material/Alert/Alert";
 
 const initialFields: InsertSchema["collection_centres"] = {
     name: "",
@@ -46,13 +47,14 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
     const [submitErrorMessage, setSubmitErrorMessage] = useState("");
     const [submitDisabled, setSubmitDisabled] = useState(false);
 
-    const [refreshRequired, setRefreshRequired] = useState(false);
+    const [addCollectionCentreIsSuccess, setAddCollectionCentreIsSuccess] = useState(false);
 
     const fieldSetter = setField(setFields, fields);
     const errorSetter = setError(setFormErrors, formErrors);
 
     const submitForm = async (): Promise<void> => {
         setSubmitDisabled(true);
+        setAddCollectionCentreIsSuccess(false);
 
         if (checkErrorOnSubmit(formErrors, setFormErrors)) {
             setSubmitDisabled(false);
@@ -84,9 +86,9 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
 
         setSubmitErrorMessage("");
         setSubmitDisabled(false);
-        setRefreshRequired(true);
         await sendAuditLog({ ...auditLog, wasSuccess: true, collectionCentreId: data.primary_key });
         void logInfoReturnLogId(`Collection centre: ${fields.name} has been created successfully.`);
+        setAddCollectionCentreIsSuccess(true);
     };
 
     return (
@@ -102,8 +104,10 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
                     />
                 ))}
 
-                {refreshRequired ? (
-                    <RefreshPageButton />
+                {addCollectionCentreIsSuccess ? (
+                    <Alert severity="success" action={<RefreshPageButton />}>
+                        Collection centre <b>{fields.name}</b> added successfully.
+                    </Alert>
                 ) : (
                     <Button
                         startIcon={<FontAwesomeIcon icon={faBuildingCircleArrowRight} />}

--- a/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
+++ b/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
@@ -48,6 +48,7 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
     const [submitDisabled, setSubmitDisabled] = useState(false);
 
     const [addCollectionCentreIsSuccess, setAddCollectionCentreIsSuccess] = useState(false);
+    const [newCollectionCentre, setNewCollectionCentre] = useState<string | null>(null);
 
     const fieldSetter = setField(setFields, fields);
     const errorSetter = setError(setFormErrors, formErrors);
@@ -87,7 +88,8 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
         setSubmitErrorMessage("");
         setSubmitDisabled(false);
         await sendAuditLog({ ...auditLog, wasSuccess: true, collectionCentreId: data.primary_key });
-        void logInfoReturnLogId(`Collection centre: ${fields.name} has been created successfully.`);
+        void logInfoReturnLogId(`Collection centre: ${data.name} has been created successfully.`);
+        setNewCollectionCentre(data.name);
         setAddCollectionCentreIsSuccess(true);
     };
 
@@ -106,7 +108,7 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
 
                 {addCollectionCentreIsSuccess ? (
                     <Alert severity="success" action={<RefreshPageButton />}>
-                        Collection centre <b>{fields.name}</b> added successfully.
+                        Collection centre <b>{newCollectionCentre}</b> added successfully.
                     </Alert>
                 ) : (
                     <Button

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,10 +2,7 @@ import React, { ReactElement } from "react";
 import Title from "@/components/Title/Title";
 import { Metadata } from "next";
 import AdminPage from "@/app/admin/AdminPage";
-import { getSupabaseServerComponentClient } from "@/supabaseServer";
-import { DatabaseError } from "@/app/errorClasses";
-import { Schema, UserRole } from "@/databaseUtils";
-import { logErrorReturnLogId } from "@/logger/logger";
+import { UserRole } from "@/databaseUtils";
 
 // disables caching
 export const revalidate = 0;
@@ -22,28 +19,11 @@ export interface UserRow {
     updatedAt: number | null;
 }
 
-const getCollectionCentres = async (): Promise<Schema["collection_centres"][]> => {
-    const supabase = getSupabaseServerComponentClient();
-    const { data, error } = await supabase.from("collection_centres").select();
-
-    // TODO VFB-23 Move error handling of this request to client side
-    if (error) {
-        const logId = await logErrorReturnLogId("Error with fetch: Collection Centres", {
-            error: error,
-        });
-        throw new DatabaseError("fetch", "collection centres", logId);
-    }
-
-    return data;
-};
-
 const Admin = async (): Promise<ReactElement> => {
-    const collectionCentreData = await getCollectionCentres();
-
     return (
         <main>
             <Title>Admin Panel</Title>
-            <AdminPage collectionCentreData={collectionCentreData} />
+            <AdminPage />
         </main>
     );
 };


### PR DESCRIPTION
## What's changed
- Collection centres table update automatically after adding a new centre
- Success message is displayed

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/b9ab676d-4435-48fe-b314-72448261a832) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/1cb270fe-cad0-4047-98b0-984bacc0e383) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... N/A
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
