### PR TITLE
VFB-158: Fetch statuses from database instead of from list

### DIFF
--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -128,7 +128,7 @@ const Statuses: React.FC<Props> = ({
             setParcelStatuses(parcelStatusesData);
         };
         void getParcelStatuses();
-    }, []);
+    }, [setModalError]);
 
     const submitStatus = async (date: Dayjs): Promise<void> => {
         willSaveParcelStatus();

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -13,9 +13,9 @@ import { sendAuditLog } from "@/server/auditLog";
 import { ParcelStatus } from "@/databaseUtils";
 import { fetchParcelStatuses } from "@/app/parcels/fetchParcelTableData";
 
-export type statusType = ParcelStatus[][number];
+export type StatusType = ParcelStatus[][number];
 
-const nonMenuStatuses: statusType[] = [
+const nonMenuStatuses: StatusType[] = [
     "Shipping Labels Downloaded",
     "Shopping List Downloaded",
     "Out for Delivery",

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -41,7 +41,7 @@ export const saveParcelStatus = async (
     const eventsToInsert = parcelIds
         .map((parcelId: string) => {
             return {
-                event_name: statusName,
+                new_parcel_status: statusName,
                 parcel_id: parcelId,
                 event_data: statusEventData,
                 timestamp,

--- a/src/app/parcels/ParcelsPage.cy.tsx
+++ b/src/app/parcels/ParcelsPage.cy.tsx
@@ -74,9 +74,9 @@ const sampleRawExpandedClientDetails: RawParcelDetails = {
     },
 
     events: [
-        { event_name: "Event 1", timestamp: "2023-06-04T13:30:00+00:00", event_data: "" },
+        { new_parcel_status: "Event 1", timestamp: "2023-06-04T13:30:00+00:00", event_data: "" },
         {
-            event_name: "Event 2",
+            new_parcel_status: "Event 2",
             timestamp: "2023-06-04T13:30:00+00:00",
             event_data: "Something happened",
         },
@@ -259,12 +259,12 @@ describe("Parcels Page", () => {
             expect(
                 processEventsDetails([
                     {
-                        event_name: "Event 1",
+                        new_parcel_status: "Event 1",
                         timestamp: "2023-08-04T13:30:00+00:00",
                         event_data: "",
                     },
                     {
-                        event_name: "Event 2",
+                        new_parcel_status: "Event 2",
                         timestamp: "2023-06-04T15:30:00+00:00",
                         event_data: "Message",
                     },

--- a/src/app/parcels/fetchParcelTableData.ts
+++ b/src/app/parcels/fetchParcelTableData.ts
@@ -4,6 +4,8 @@ import { ParcelsTableRow, processingDataToParcelsTableData } from "./getParcelsT
 import { Filter, PaginationType } from "@/components/Tables/Filters";
 import { SortState } from "@/components/Tables/Table";
 import { logErrorReturnLogId, logInfoReturnLogId } from "@/logger/logger";
+import supabase from "@/supabaseClient";
+import { ParcelStatus } from "@/databaseUtils";
 
 export type CongestionChargeDetails = {
     postcode: string;
@@ -202,3 +204,34 @@ export interface CollectionCentresOptions {
 export interface StatusResponseRow {
     event_name: string;
 }
+
+type ParcelStatusesError = "failedToFetchStatuses";
+type ParcelStatusesReturnType =
+    | {
+          data: ParcelStatus[];
+          error: null;
+      }
+    | {
+          data: null;
+          error: { type: ParcelStatusesError; logId: string };
+      };
+
+export const fetchParcelStatuses = async (): Promise<ParcelStatusesReturnType> => {
+    const { data: parcelStatusesListData, error: statusOrderError } = await supabase
+        .from("status_order")
+        .select("event_name")
+        .order("workflow_order");
+
+    if (statusOrderError) {
+        const logId = await logErrorReturnLogId("failed to fetch statuses", {
+            error: statusOrderError,
+        });
+        return { data: null, error: { type: "failedToFetchStatuses", logId } };
+    }
+
+    const parcelStatusesList = parcelStatusesListData.map((status) => {
+        return status.event_name;
+    });
+
+    return { data: parcelStatusesList, error: null };
+};

--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -39,7 +39,7 @@ export const getRawParcelDetails = async (parcelId: string) => {
             )
         ),
         events:events (
-            event_name,
+            new_parcel_status,
             timestamp,
             event_data
         )
@@ -205,10 +205,10 @@ export const formatBreakdownOfChildrenFromFamilyDetails = (
 };
 
 export const processEventsDetails = (
-    events: Pick<Schema["events"], "event_data" | "event_name" | "timestamp">[]
+    events: Pick<Schema["events"], "event_data" | "new_parcel_status" | "timestamp">[]
 ): EventTableRow[] => {
     return events.map((event) => ({
-        eventInfo: event.event_name + (event.event_data ? ` (${event.event_data})` : ""),
+        eventInfo: event.new_parcel_status + (event.event_data ? ` (${event.event_data})` : ""),
         timestamp: new Date(event.timestamp),
     }));
 };

--- a/src/databaseTypesFile.ts
+++ b/src/databaseTypesFile.ts
@@ -266,26 +266,33 @@ export type Database = {
       events: {
         Row: {
           event_data: string | null
-          event_name: string
+          new_parcel_status: string
           parcel_id: string
           primary_key: string
           timestamp: string
         }
         Insert: {
           event_data?: string | null
-          event_name: string
+          new_parcel_status: string
           parcel_id: string
           primary_key?: string
           timestamp?: string
         }
         Update: {
           event_data?: string | null
-          event_name?: string
+          new_parcel_status?: string
           parcel_id?: string
           primary_key?: string
           timestamp?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "events_new_parcel_status_fkey"
+            columns: ["new_parcel_status"]
+            isOneToOne: false
+            referencedRelation: "status_order"
+            referencedColumns: ["event_name"]
+          },
           {
             foreignKeyName: "events_parcel_id_fkey"
             columns: ["parcel_id"]
@@ -687,7 +694,15 @@ export type Database = {
           timestamp: string | null
           workflow_order: number | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "events_new_parcel_status_fkey"
+            columns: ["event_name"]
+            isOneToOne: false
+            referencedRelation: "status_order"
+            referencedColumns: ["event_name"]
+          },
+        ]
       }
       parcels_plus: {
         Row: {
@@ -711,7 +726,15 @@ export type Database = {
           parcel_id: string | null
           voucher_number: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "events_new_parcel_status_fkey"
+            columns: ["last_status_event_name"]
+            isOneToOne: false
+            referencedRelation: "status_order"
+            referencedColumns: ["event_name"]
+          },
+        ]
       }
       profiles_plus: {
         Row: {

--- a/src/databaseUtils.ts
+++ b/src/databaseUtils.ts
@@ -27,3 +27,5 @@ export type ViewSchema = {
 export type TableNames = keyof Tables;
 
 export type ViewNames = keyof Views;
+
+export type ParcelStatus = Schema["status_order"]["event_name"];

--- a/supabase/migrations/20240418083600_add_fk_to_status_order_table_from_events_table.sql
+++ b/supabase/migrations/20240418083600_add_fk_to_status_order_table_from_events_table.sql
@@ -1,0 +1,59 @@
+drop view if exists "public"."parcels_plus";
+
+drop view if exists "public"."last_status";
+
+alter table "public"."events" rename column "event_name" to "new_parcel_status";
+
+alter table "public"."events" add constraint "events_new_parcel_status_fkey" FOREIGN KEY (new_parcel_status) REFERENCES status_order(event_name) not valid;
+
+alter table "public"."events" validate constraint "events_new_parcel_status_fkey";
+
+create or replace view "public"."last_status" as  WITH latest_events AS (
+         SELECT e.parcel_id,
+            e.new_parcel_status AS event_name,
+            e."timestamp",
+            e.event_data,
+            o.workflow_order,
+            row_number() OVER (PARTITION BY e.parcel_id ORDER BY e."timestamp" DESC, e.parcel_id) AS row_num
+           FROM (events e
+             LEFT JOIN status_order o ON ((o.event_name = e.new_parcel_status)))
+        )
+ SELECT p.primary_key AS parcel_id,
+    le.event_name,
+    le."timestamp",
+    le.event_data,
+    le.workflow_order
+   FROM (parcels p
+     LEFT JOIN latest_events le ON (((p.primary_key = le.parcel_id) AND (le.row_num = 1))))
+  ORDER BY COALESCE(le.workflow_order, (9999)::bigint);
+
+
+create or replace view "public"."parcels_plus" as  SELECT parcels.primary_key AS parcel_id,
+    parcels.collection_datetime,
+    parcels.packing_date,
+    packing_slots.name AS packing_slot_name,
+    packing_slots."order" AS packing_slot_order,
+    parcels.voucher_number,
+    collection_centres.name AS collection_centre_name,
+    collection_centres.acronym AS collection_centre_acronym,
+    clients.primary_key AS client_id,
+    clients.full_name AS client_full_name,
+    clients.address_postcode AS client_address_postcode,
+    clients.flagged_for_attention AS client_flagged_for_attention,
+    clients.signposting_call_required AS client_signposting_call_required,
+    clients.phone_number AS client_phone_number,
+    family_count.family_count,
+    last_status.event_name AS last_status_event_name,
+    last_status.event_data AS last_status_event_data,
+    last_status."timestamp" AS last_status_timestamp,
+    last_status.workflow_order AS last_status_workflow_order
+   FROM (((((parcels
+     JOIN collection_centres ON ((parcels.collection_centre = collection_centres.primary_key)))
+     JOIN clients ON ((parcels.client_id = clients.primary_key)))
+     JOIN packing_slots ON ((parcels.packing_slot = packing_slots.primary_key)))
+     LEFT JOIN family_count ON ((family_count.family_id = clients.family_id)))
+     LEFT JOIN last_status ON ((last_status.parcel_id = parcels.primary_key)))
+  ORDER BY parcels.packing_date DESC;
+
+
+

--- a/supabase/seed/seed.mts
+++ b/supabase/seed/seed.mts
@@ -90,7 +90,7 @@ async function generateSeed(): Promise<void> {
     for (const status of eventNamesWithNumberData) {
         await seed.events(
             (generate) =>
-                generate(4000, {
+                generate(1000, {
                     newParcelStatus: status,
                     eventData: (ctx) => copycat.int(ctx.seed, { min: 1, max: 10 }).toString(),
                     timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
@@ -102,7 +102,7 @@ async function generateSeed(): Promise<void> {
     for (const status of eventNamesWithNoData) {
         await seed.events(
             (generate) =>
-                generate(10000, {
+                generate(1000, {
                     newParcelStatus: status,
                     eventData: (ctx) => copycat.int(ctx.seed, { min: 1, max: 10 }).toString(),
                     timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),

--- a/supabase/seed/seed.mts
+++ b/supabase/seed/seed.mts
@@ -87,23 +87,27 @@ async function generateSeed(): Promise<void> {
         { connect: true }
     );
 
-    await seed.events(
-        (generate) =>
-            generate(4000, {
-                newParcelStatus: (ctx) => copycat.oneOfString(ctx.seed, eventNamesWithNumberData),
-                eventData: (ctx) => copycat.int(ctx.seed, { min: 1, max: 10 }).toString(),
-                timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
-            }),
-        { connect: true }
-    );
+    for (const status of eventNamesWithNumberData) {
+        await seed.events(
+            (generate) =>
+                generate(4000, {
+                    newParcelStatus: status,
+                    eventData: (ctx) => copycat.int(ctx.seed, { min: 1, max: 10 }).toString(),
+                    timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
+                }),
+            { connect: true }
+        );
+    }
 
-    await seed.events(
-        (generate) =>
-            generate(10000, {
-                newParcelStatus: (ctx) => copycat.oneOfString(ctx.seed, eventNamesWithNoData),
-                eventData: "",
-                timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
-            }),
-        { connect: true }
-    );
+    for (const status of eventNamesWithNoData) {
+        await seed.events(
+            (generate) =>
+                generate(10000, {
+                    newParcelStatus: status,
+                    eventData: (ctx) => copycat.int(ctx.seed, { min: 1, max: 10 }).toString(),
+                    timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
+                }),
+            { connect: true }
+        );
+    }
 }

--- a/supabase/seed/seed.mts
+++ b/supabase/seed/seed.mts
@@ -104,7 +104,7 @@ async function generateSeed(): Promise<void> {
             (generate) =>
                 generate(1000, {
                     newParcelStatus: status,
-                    eventData: (ctx) => copycat.int(ctx.seed, { min: 1, max: 10 }).toString(),
+                    eventData: (ctx) => "",
                     timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
                 }),
             { connect: true }

--- a/supabase/seed/seed.mts
+++ b/supabase/seed/seed.mts
@@ -93,7 +93,8 @@ async function generateSeed(): Promise<void> {
                 generate(1000, {
                     newParcelStatus: status,
                     eventData: (ctx) => copycat.int(ctx.seed, { min: 1, max: 10 }).toString(),
-                    timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
+                    timestamp: (ctx) =>
+                        getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
                 }),
             { connect: true }
         );
@@ -104,8 +105,9 @@ async function generateSeed(): Promise<void> {
             (generate) =>
                 generate(1000, {
                     newParcelStatus: status,
-                    eventData: (ctx) => "",
-                    timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
+                    eventData: () => "",
+                    timestamp: (ctx) =>
+                        getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
                 }),
             { connect: true }
         );

--- a/supabase/seed/seed.mts
+++ b/supabase/seed/seed.mts
@@ -90,7 +90,7 @@ async function generateSeed(): Promise<void> {
     await seed.events(
         (generate) =>
             generate(4000, {
-                eventName: (ctx) => copycat.oneOfString(ctx.seed, eventNamesWithNumberData),
+                newParcelStatus: (ctx) => copycat.oneOfString(ctx.seed, eventNamesWithNumberData),
                 eventData: (ctx) => copycat.int(ctx.seed, { min: 1, max: 10 }).toString(),
                 timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
             }),
@@ -100,7 +100,7 @@ async function generateSeed(): Promise<void> {
     await seed.events(
         (generate) =>
             generate(10000, {
-                eventName: (ctx) => copycat.oneOfString(ctx.seed, eventNamesWithNoData),
+                newParcelStatus: (ctx) => copycat.oneOfString(ctx.seed, eventNamesWithNoData),
                 eventData: "",
                 timestamp: (ctx) => getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
             }),


### PR DESCRIPTION
## What's changed
- Fetch statuses from status_order table instead of predetermined list from front end.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| paste_here | paste_here |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... N/A
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [x] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [x] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [x] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [x] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
