### PR TITLE
VFB-197 fix: Remove refresh button from alert

### DIFF
--- a/src/app/admin/common/SuccessFailureAlert.tsx
+++ b/src/app/admin/common/SuccessFailureAlert.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Alert from "@mui/material/Alert/Alert";
-import RefreshPageButton from "@/app/admin/common/RefreshPageButton";
 
 export type AlertOptions = {
     success: boolean | undefined;
@@ -19,11 +18,7 @@ const SuccessFailureAlert: React.FC<Props> = ({ alertOptions, onClose }) => {
     }
 
     return (
-        <Alert
-            severity={alertOptions.success ? "success" : "error"}
-            action={alertOptions.success ? <RefreshPageButton /> : undefined}
-            onClose={onClose}
-        >
+        <Alert severity={alertOptions.success ? "success" : "error"} onClose={onClose}>
             {alertOptions.message}
         </Alert>
     );


### PR DESCRIPTION
## What's changed
- Removed refresh button from success message when user is deleted

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/e12c3f52-5434-49cc-b267-2f847b958f80) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/9cbab14a-ae80-47f7-be55-d2cd667a1423) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
