### PR TITLE
#242: Make phone number optional when adding a user

### DIFF
--- a/cypress/e2e/admin/inviteUser.cy.ts
+++ b/cypress/e2e/admin/inviteUser.cy.ts
@@ -8,7 +8,7 @@ describe("User invite on admins page", () => {
 
     it("Invite a user without a phone number", () => {
         const email = generateRandomEmailAddress();
-        
+
         toggleCreateUserSection();
         fillEmail(email);
         fillFirstName("First");

--- a/cypress/e2e/admin/inviteUser.cy.ts
+++ b/cypress/e2e/admin/inviteUser.cy.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 describe("User invite on admins page", () => {
     beforeEach(() => {
         cy.login();
@@ -5,18 +7,20 @@ describe("User invite on admins page", () => {
     });
 
     it("Invite a user without a phone number", () => {
-        const email = "new-user-without-phone-number@emxaple.com";
+        const email = generateRandomEmailAddress();
+        
         toggleCreateUserSection();
         fillEmail(email);
         fillFirstName("First");
         fillLastName("Last");
         clickInviteUser();
-        cy.contains("Failed to create a profile for the new user.").should("be.visible");
+
+        assertUserInvitedSuccessfully(email);
     });
 
     it("Invite a user without a phone number after typing a number first", () => {
-        // open the invite user section
-        const email = "new-user-without-phone-number-after-filling-in@emxaple.com";
+        const email = generateRandomEmailAddress();
+
         toggleCreateUserSection();
         fillEmail(email);
         fillFirstName("First");
@@ -24,11 +28,13 @@ describe("User invite on admins page", () => {
         fillPhoneNumber("00000000000");
         clearPhoneNumber();
         clickInviteUser();
+
+        assertUserInvitedSuccessfully(email);
     });
 
     it("Invite a user with a phone number", () => {
-        // open the invite user section
-        const email = "new-user-with-phone-number@emxaple.com";
+        const email = generateRandomEmailAddress();
+
         toggleCreateUserSection();
         fillEmail(email);
         fillFirstName("First");
@@ -36,7 +42,7 @@ describe("User invite on admins page", () => {
         fillPhoneNumber("00000000000");
         clickInviteUser();
 
-        cy.contains(`User ${email} invited successfully.`).should("be.visible");
+        assertUserInvitedSuccessfully(email);
     });
 
     const createUserText = "create user";
@@ -71,5 +77,13 @@ describe("User invite on admins page", () => {
 
     function clickInviteUser(): void {
         cy.contains("Invite User").click();
+    }
+
+    function assertUserInvitedSuccessfully(email: string): void {
+        cy.contains(`User ${email} invited successfully.`).should("be.visible");
+    }
+
+    function generateRandomEmailAddress(): string {
+        return `${uuidv4()}@example.com`;
     }
 });

--- a/cypress/e2e/admin/inviteUser.cy.ts
+++ b/cypress/e2e/admin/inviteUser.cy.ts
@@ -1,0 +1,75 @@
+describe("User invite on admins page", () => {
+    beforeEach(() => {
+        cy.login();
+        cy.visit("/admin");
+    });
+
+    it("Invite a user without a phone number", () => {
+        const email = "new-user-without-phone-number@emxaple.com";
+        toggleCreateUserSection();
+        fillEmail(email);
+        fillFirstName("First");
+        fillLastName("Last");
+        clickInviteUser();
+        cy.contains("Failed to create a profile for the new user.").should("be.visible");
+    });
+
+    it("Invite a user without a phone number after typing a number first", () => {
+        // open the invite user section
+        const email = "new-user-without-phone-number-after-filling-in@emxaple.com";
+        toggleCreateUserSection();
+        fillEmail(email);
+        fillFirstName("First");
+        fillLastName("Last");
+        fillPhoneNumber("00000000000");
+        clearPhoneNumber();
+        clickInviteUser();
+    });
+
+    it("Invite a user with a phone number", () => {
+        // open the invite user section
+        const email = "new-user-with-phone-number@emxaple.com";
+        toggleCreateUserSection();
+        fillEmail(email);
+        fillFirstName("First");
+        fillLastName("Last");
+        fillPhoneNumber("00000000000");
+        clickInviteUser();
+
+        cy.contains(`User ${email} invited successfully.`).should("be.visible");
+    });
+
+    const createUserText = "create user";
+
+    function toggleCreateUserSection(): void {
+        cy.contains(createUserText, { matchCase: false }).click();
+    }
+
+    function fillEmail(value: string): void {
+        fillTextboxWithId("new-user-email-address", value);
+    }
+
+    function fillFirstName(value: string): void {
+        fillTextboxWithId("new-user-first-name", value);
+    }
+
+    function fillLastName(value: string): void {
+        fillTextboxWithId("new-user-last-name", value);
+    }
+
+    function fillPhoneNumber(value: string): void {
+        fillTextboxWithId("new-user-phone-number", value);
+    }
+
+    function clearPhoneNumber(): void {
+        cy.get("#new-user-phone-number").clear();
+    }
+
+    function fillTextboxWithId(id: string, value: string): void {
+        cy.get(`#${id}`).type(value);
+    }
+
+    function clickInviteUser(): void {
+        cy.contains("Invite User").click();
+    }
+});

--- a/src/app/admin/createUser/AccountDetails.tsx
+++ b/src/app/admin/createUser/AccountDetails.tsx
@@ -14,6 +14,7 @@ const AccountDetails: React.FC<CardProps> = ({ fieldSetter, formErrors, errorSet
         >
             <>
                 <FreeFormTextInput
+                    id="new-user-email-address"
                     label="Email"
                     error={errorExists(formErrors.email)}
                     helperText={errorText(formErrors.email)}

--- a/src/app/admin/createUser/CreateUserForm.tsx
+++ b/src/app/admin/createUser/CreateUserForm.tsx
@@ -43,7 +43,7 @@ const initialFormErrors: FormErrors = {
     role: Errors.none,
     firstName: Errors.initial,
     lastName: Errors.initial,
-    telephoneNumber: Errors.initial,
+    telephoneNumber: Errors.none,
 };
 
 const getServerErrorMessage = (serverError: InviteUserError): string => {

--- a/src/app/admin/createUser/UserDetailsCard.tsx
+++ b/src/app/admin/createUser/UserDetailsCard.tsx
@@ -31,7 +31,7 @@ const UserDetailsCard: React.FC<CardProps> = ({ fieldSetter, formErrors, errorSe
                     fieldSetter,
                     errorSetter,
                     "telephoneNumber",
-                    true,
+                    false,
                     telephoneRegex
                 )}
             />

--- a/src/app/admin/createUser/UserDetailsCard.tsx
+++ b/src/app/admin/createUser/UserDetailsCard.tsx
@@ -12,18 +12,21 @@ const UserDetailsCard: React.FC<CardProps> = ({ fieldSetter, formErrors, errorSe
             required
         >
             <FreeFormTextInput
+                id="new-user-first-name"
                 label="First Name"
                 error={errorExists(formErrors.firstName)}
                 helperText={errorText(formErrors.firstName)}
                 onChange={onChangeText(fieldSetter, errorSetter, "firstName", true)}
             />
             <FreeFormTextInput
+                id="new-user-last-name"
                 label="Last Name"
                 error={errorExists(formErrors.lastName)}
                 helperText={errorText(formErrors.lastName)}
                 onChange={onChangeText(fieldSetter, errorSetter, "lastName", true)}
             />
             <FreeFormTextInput
+                id="new-user-phone-number"
                 label="Telephone Number"
                 error={errorExists(formErrors.telephoneNumber)}
                 helperText={errorText(formErrors.telephoneNumber)}

--- a/src/components/DataInput/FreeFormTextInput.tsx
+++ b/src/components/DataInput/FreeFormTextInput.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { TextField } from "@mui/material";
 interface Props {
+    id?: string;
     label?: string;
     defaultValue?: string;
     type?: string;

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -75,15 +75,17 @@ const getErrorType = (
     regex?: RegExp,
     additionalCondition?: (value: string) => boolean
 ): Errors => {
-    if (required && input === "") {
-        return Errors.required;
+    if (input == "") {
+        return required ? Errors.required : Errors.none;
     }
+
     if (
         (regex !== undefined && !input.match(regex)) ||
         (additionalCondition !== undefined && !additionalCondition(input))
     ) {
         return Errors.invalid;
     }
+
     return Errors.none;
 };
 


### PR DESCRIPTION
## What's changed
- Make phone number optional when adding a user
- If the input is an empty string and the field isn't required, return no validation error.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... Nope
