### PR TITLE
VFB-202: Add created_at column in audit_log table

### DIFF
--- a/src/databaseTypesFile.ts
+++ b/src/databaseTypesFile.ts
@@ -15,6 +15,7 @@ export type Database = {
           client_id: string | null
           collection_centre_id: string | null
           content: Json | null
+          created_at: string | null
           event_id: string | null
           list_hotel_id: string | null
           list_id: string | null
@@ -33,6 +34,7 @@ export type Database = {
           client_id?: string | null
           collection_centre_id?: string | null
           content?: Json | null
+          created_at?: string | null
           event_id?: string | null
           list_hotel_id?: string | null
           list_id?: string | null
@@ -51,6 +53,7 @@ export type Database = {
           client_id?: string | null
           collection_centre_id?: string | null
           content?: Json | null
+          created_at?: string | null
           event_id?: string | null
           list_hotel_id?: string | null
           list_id?: string | null

--- a/supabase/migrations/20240418124604_add_created_at_column_audit_log_table.sql
+++ b/supabase/migrations/20240418124604_add_created_at_column_audit_log_table.sql
@@ -1,0 +1,3 @@
+alter table "public"."audit_log" add column "created_at" timestamp with time zone default current_timestamp;
+update "public"."audit_log" set created_at = current_timestamp;
+alter table "public"."audit_log" alter column "created_at" set not null;


### PR DESCRIPTION
## What's changed
- Add column created_at to audit_log table
- Column default set to utc
- Set existing audit log rows to utc at time of migration

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| paste_here | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/7c1e1884-3ef7-4a0c-8fbe-fed367139dd7) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [N/A] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [N/A] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [x] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate) Not sure?
  - [x] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
