### PR TITLE
VFB-158-FIX: Exclude automatically generated statuses from status list

### DIFF
--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -16,10 +16,12 @@ import { fetchParcelStatuses } from "@/app/parcels/fetchParcelTableData";
 export type StatusType = ParcelStatus[][number];
 
 const nonMenuStatuses: StatusType[] = [
-    "Shipping Labels Downloaded",
-    "Shopping List Downloaded",
+    "Driver Overview Downloaded",
+    "Map Generated",
     "Out for Delivery",
     "Request Deleted",
+    "Shipping Labels Downloaded",
+    "Shopping List Downloaded",
 ];
 
 type SaveParcelStatusErrorType = "eventInsertionFailed";
@@ -125,6 +127,7 @@ const Statuses: React.FC<Props> = ({
                         return;
                 }
             }
+            console.log(parcelStatusesData);
             setParcelStatuses(parcelStatusesData);
         };
         void getParcelStatuses();


### PR DESCRIPTION
## What's changed
- Exclude automatically generated statuses from status list (eg. Driver Overview Downloaded, Map Generated)

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/1e1e3f61-be19-496c-b815-9ecb99bb18c7) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/160640328/f8025f75-a679-42f0-b975-b92f645ba898) |

## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [ ] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
