### PR TITLE
VFB-175: Fix

### DIFF
--- a/src/app/admin/createCollectionCentre/AcronymCard.tsx
+++ b/src/app/admin/createCollectionCentre/AcronymCard.tsx
@@ -3,7 +3,7 @@ import FreeFormTextInput from "@/components/DataInput/FreeFormTextInput";
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { CardProps, errorExists, errorText, onChangeText } from "@/components/Form/formFunctions";
 
-const Acronymcard: React.FC<CardProps> = ({ fieldSetter, formErrors, errorSetter }) => {
+const AcronymCard: React.FC<CardProps> = ({ fieldSetter, formErrors, errorSetter }) => {
     return (
         <GenericFormCard
             title="Acronym"
@@ -20,4 +20,4 @@ const Acronymcard: React.FC<CardProps> = ({ fieldSetter, formErrors, errorSetter
     );
 };
 
-export default Acronymcard;
+export default AcronymCard;

--- a/src/app/parcels/ActionBar/ActionModals/DayOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DayOverviewModal.tsx
@@ -81,6 +81,7 @@ const DayOverviewInput: React.FC<DayOverviewInputProps> = ({
                         setDateValid();
                     }
                 }}
+                onAccept={setDateValid}
             />
         </>
     );

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -58,7 +58,7 @@ export const saveParcelStatus = async (
     }));
 
     const { data, error } = await supabase
-        .from("events")
+        .from("ss")
         .insert(eventsToInsert)
         .select("event_id:primary_key, parcel_id");
 
@@ -152,7 +152,7 @@ const Statuses: React.FC<Props> = ({
             setServerErrorMessage(`${getStatusErrorMessage(error)} Log ID: ${error.logId}`);
         }
         hasAttemptedToSaveParcelStatus();
-        setStatusModal(false);
+        error ?? setStatusModal(false);
     };
 
     const onMenuItemClick = (status: StatusType): (() => void) => {


### PR DESCRIPTION
## What's changed
- Keep status modal open if the status change fails, so that the user can see the error message
- When selecting a date via the calendar view on the Day Overview Modal, a valid date now enables the PDF download button

## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [ ] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test:e2e`

No DB changes.
