### PR TITLE
VFB-154/204 - Fix status not updating bug by making new status times exact

### DIFF
--- a/src/app/parcels/ActionBar/ActionAndStatusBar.cy.tsx
+++ b/src/app/parcels/ActionBar/ActionAndStatusBar.cy.tsx
@@ -77,8 +77,6 @@ describe("Parcels - Action Bar", () => {
                     <ActionAndStatusBar
                         fetchSelectedParcels={fetchSelectedParcels}
                         updateParcelStatuses={onDeleteParcels}
-                        hasAttemptedToSaveParcelStatus={() => {}}
-                        willSaveParcelStatus={() => {}}
                     />
                 </StyleManager>
             </Localization>
@@ -98,8 +96,6 @@ describe("Parcels - Action Bar", () => {
                         await mockData.filter((parcel) => parcelIds.includes(parcel.parcelId))
                     }
                     updateParcelStatuses={onDeleteParcels}
-                    hasAttemptedToSaveParcelStatus={() => {}}
-                    willSaveParcelStatus={() => {}}
                 />
             );
         });
@@ -179,8 +175,6 @@ describe("Parcels - Action Bar", () => {
                         await mockData.filter((parcel) => parcelIds.includes(parcel.parcelId))
                     }
                     updateParcelStatuses={onDeleteParcels}
-                    hasAttemptedToSaveParcelStatus={() => {}}
-                    willSaveParcelStatus={() => {}}
                 />
             );
         });

--- a/src/app/parcels/ActionBar/ActionAndStatusBar.tsx
+++ b/src/app/parcels/ActionBar/ActionAndStatusBar.tsx
@@ -12,8 +12,6 @@ import { ArrowDropDown } from "@mui/icons-material";
 export interface ActionAndStatusBarProps {
     fetchSelectedParcels: () => Promise<ParcelsTableRow[]>;
     updateParcelStatuses: UpdateParcelStatuses;
-    willSaveParcelStatus: () => void;
-    hasAttemptedToSaveParcelStatus: () => void;
 }
 
 export type UpdateParcelStatuses = (
@@ -41,8 +39,6 @@ const ActionAndStatusBar: React.FC<ActionAndStatusBarProps> = (props) => {
                 statusAnchorElement={statusAnchorElement}
                 setStatusAnchorElement={setStatusAnchorElement}
                 setModalError={setModalError}
-                willSaveParcelStatus={props.willSaveParcelStatus}
-                hasAttemptedToSaveParcelStatus={props.hasAttemptedToSaveParcelStatus}
             />
             <Actions
                 fetchSelectedParcels={props.fetchSelectedParcels}

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -86,8 +86,6 @@ interface Props {
     statusAnchorElement: HTMLElement | null;
     setStatusAnchorElement: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
     setModalError: React.Dispatch<React.SetStateAction<string | null>>;
-    willSaveParcelStatus: () => void;
-    hasAttemptedToSaveParcelStatus: () => void;
 }
 
 const getStatusErrorMessage = (statusError: SaveParcelStatusError): string => {
@@ -105,8 +103,6 @@ const Statuses: React.FC<Props> = ({
     statusAnchorElement,
     setStatusAnchorElement,
     setModalError,
-    willSaveParcelStatus,
-    hasAttemptedToSaveParcelStatus,
 }) => {
     const [selectedParcels, setSelectedParcels] = useState<ParcelsTableRow[]>([]);
     const [selectedStatus, setSelectedStatus] = useState<StatusType | null>(null);
@@ -133,11 +129,9 @@ const Statuses: React.FC<Props> = ({
     }, [setModalError]);
 
     const submitStatus = async (date: Dayjs): Promise<void> => {
-        willSaveParcelStatus();
         setServerErrorMessage(null);
         if (selectedStatus === null) {
             setServerErrorMessage("Chosen status was not found.");
-            hasAttemptedToSaveParcelStatus();
             return;
         }
         const { error } = await saveParcelStatus(
@@ -151,7 +145,6 @@ const Statuses: React.FC<Props> = ({
         if (error) {
             setServerErrorMessage(`${getStatusErrorMessage(error)} Log ID: ${error.logId}`);
         }
-        hasAttemptedToSaveParcelStatus();
         if (!error) {
             setStatusModal(false);
         }

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -39,7 +39,7 @@ export const saveParcelStatus = async (
     statusEventData?: string | null,
     date?: Dayjs | null
 ): Promise<SaveParcelStatusResult> => {
-    const timestamp = (date ?? dayjs()).set("second", 0).toISOString();
+    const timestamp = (date ?? dayjs()).toISOString();
     const eventsToInsert = parcelIds
         .map((parcelId: string) => {
             return {

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -566,14 +566,12 @@ const ParcelsPage: React.FC<{}> = () => {
         newStatus: StatusType,
         statusEventData?: string
     ): Promise<SaveParcelStatusResult> => {
-        setIsLoading(true);
         const { error } = await saveParcelStatus(
             parcels.map((parcel) => parcel.parcelId),
             newStatus,
             statusEventData
         );
         setCheckedParcelIds([]);
-        setIsLoading(false);
         return { error: error };
     };
 
@@ -599,8 +597,6 @@ const ParcelsPage: React.FC<{}> = () => {
                     <ActionAndStatusBar
                         fetchSelectedParcels={getCheckedParcelsData}
                         updateParcelStatuses={updateParcelStatuses}
-                        willSaveParcelStatus={() => setIsLoading(true)}
-                        hasAttemptedToSaveParcelStatus={() => setIsLoading(false)}
                     />
                 </ActionsContainer>
             </PreTableControls>


### PR DESCRIPTION
## What's changed
Stop rounding new status times to the nearest minute when a parcel's status is updated via status or action modal. Thus fixed a bug where the new status of a parcel did not update (because there could be multiple latest statuses)

Also took the opportunity to simplify status/action components by removing the functionality where these components call setIsLoading(true) and setIsLoading(false) for the parcels page - this is not needed, as if the status updates, these lines are called in ParcelsPage because the realtime channel is triggered. and if the status does not update (ie, the parcel has statuses in the future or the action failed) there is no need to change isLoading.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test:e2e`

No DB changes.
