### PR TITLE
VFB-203: Show users with no name in users table

### DIFF
--- a/src/app/admin/usersTable/usersTableFilters.ts
+++ b/src/app/admin/usersTable/usersTableFilters.ts
@@ -23,14 +23,14 @@ export const firstNameSearch = (
     query: PostgrestFilterBuilder<Database["public"], any, any>,
     state: string
 ): PostgrestFilterBuilder<Database["public"], any, any> => {
-    return query.ilike("first_name", `%${state}%`);
+    return query.or(`first_name.ilike.%${state}%,first_name.is.null`);
 };
 
 export const lastNameSearch = (
     query: PostgrestFilterBuilder<Database["public"], any, any>,
     state: string
 ): PostgrestFilterBuilder<Database["public"], any, any> => {
-    return query.ilike("last_name", `%${state}%`);
+    return query.or(`last_name.ilike.%${state}%,last_name.is.null`);
 };
 
 export const emailSearch = (

--- a/src/app/admin/usersTable/usersTableFilters.ts
+++ b/src/app/admin/usersTable/usersTableFilters.ts
@@ -23,14 +23,22 @@ export const firstNameSearch = (
     query: PostgrestFilterBuilder<Database["public"], any, any>,
     state: string
 ): PostgrestFilterBuilder<Database["public"], any, any> => {
-    return query.or(`first_name.ilike.%${state}%,first_name.is.null`);
+    if (state === "") {
+        return query;
+    } else {
+        return query.ilike("first_name", `%${state}%`);
+    }
 };
 
 export const lastNameSearch = (
     query: PostgrestFilterBuilder<Database["public"], any, any>,
     state: string
 ): PostgrestFilterBuilder<Database["public"], any, any> => {
-    return query.or(`last_name.ilike.%${state}%,last_name.is.null`);
+    if (state === "") {
+        return query;
+    } else {
+        return query.ilike("last_name", `%${state}%`);
+    }
 };
 
 export const emailSearch = (


### PR DESCRIPTION
## What's changed
Fixed a bug where users with first name and/or last name equal to null were not displayed in the users table in the admin page. The null first/last name are now displayed as empty strings/blank cells.

## Screenshots / Videos
| After      |
|------------|
|![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/52c9c737-c6d1-4ca1-8e3f-f55e4d1626b4)![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/ea8f3276-d710-49ee-9e58-370c66489689)![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/138508884/bfe10ab9-6b59-42ac-b911-bb1499d5fe6c)|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

No DB changes.
