### PR TITLE
VFB-209: Audit log editing a user

### DIFF
--- a/src/app/admin/deleteUser/DeleteUserDialog.tsx
+++ b/src/app/admin/deleteUser/DeleteUserDialog.tsx
@@ -47,7 +47,7 @@ const DeleteUserDialog: React.FC<Props> = (props) => {
             return;
         }
 
-        const { error: deleteUserError } = await adminDeleteUser(props.userToDelete.id);
+        const { error: deleteUserError } = await adminDeleteUser(props.userToDelete.userId);
 
         if (deleteUserError) {
             const errorMessage = getErrorMessage(deleteUserError.type);

--- a/src/app/admin/manageUser/EditUserForm.tsx
+++ b/src/app/admin/manageUser/EditUserForm.tsx
@@ -31,7 +31,7 @@ const EditUserForm: React.FC<Props> = (props) => {
 
     const onEditConfirm = async (): Promise<void> => {
         const error = await updateUserProfile({
-            userId: props.userToEdit.id,
+            profileId: props.userToEdit.profileId,
             role: role,
         });
 

--- a/src/app/admin/manageUser/ResetPasswordForm.tsx
+++ b/src/app/admin/manageUser/ResetPasswordForm.tsx
@@ -32,7 +32,7 @@ const ResetPasswordForm: React.FC<Props> = (props) => {
 
     const onConfirmPassword = async (): Promise<void> => {
         const response = await adminUpdateUserEmailAndPassword({
-            userId: props.userToEdit.id,
+            userId: props.userToEdit.userId,
             attributes: { password },
         });
 
@@ -48,7 +48,7 @@ const ResetPasswordForm: React.FC<Props> = (props) => {
             void logInfoReturnLogId(`Password for ${props.userToEdit.email} updated successfully`);
         } else {
             const logId = await logErrorReturnLogId(
-                `Error resetting password userId: ${props.userToEdit.id}`
+                `Error resetting password userId: ${props.userToEdit.userId}`
             );
             props.onConfirm({
                 success: false,

--- a/src/app/admin/manageUser/UpdateUserProfile.ts
+++ b/src/app/admin/manageUser/UpdateUserProfile.ts
@@ -1,6 +1,8 @@
 import supabase from "@/supabaseClient";
 import { PostgrestError } from "@supabase/supabase-js";
 import { UserRole } from "@/databaseUtils";
+import { logErrorReturnLogId } from "@/logger/logger";
+import { sendAuditLog } from "@/server/auditLog";
 
 interface UpdateUserProfile {
     userId: string;
@@ -13,14 +15,37 @@ interface UpdateUserProfile {
 export async function updateUserProfile(
     userDetails: UpdateUserProfile
 ): Promise<PostgrestError | null> {
-    const { error } = await supabase
+    const { data, error } = await supabase
         .from("profiles")
         .update({
             role: userDetails.role,
         })
         .eq("user_id", userDetails.userId)
-        .select()
+        .select("profile_id:primary_key")
         .single();
 
-    return error;
+    const auditLog = {
+        action: "edit a user",
+        content: {
+            role: userDetails.role,
+            firstName: userDetails.firstName,
+            lastName: userDetails.lastName,
+            phoneNumber: userDetails.phoneNumber,
+        },
+        userId: userDetails.userId,
+    };
+
+    if (error) {
+        const logId = await logErrorReturnLogId(
+            `Error with updating user profile: user id ${userDetails.userId}`,
+            {
+                error: error,
+            }
+        );
+        await sendAuditLog({ ...auditLog, wasSuccess: false, logId });
+        return error;
+    }
+
+    await sendAuditLog({ ...auditLog, wasSuccess: true, profileId: data.profile_id });
+    return null;
 }

--- a/src/app/admin/manageUser/UpdateUserProfile.ts
+++ b/src/app/admin/manageUser/UpdateUserProfile.ts
@@ -5,7 +5,7 @@ import { logErrorReturnLogId } from "@/logger/logger";
 import { sendAuditLog } from "@/server/auditLog";
 
 interface UpdateUserProfile {
-    userId: string;
+    profileId: string;
     role: UserRole;
     firstName?: string;
     lastName?: string;
@@ -15,13 +15,12 @@ interface UpdateUserProfile {
 export async function updateUserProfile(
     userDetails: UpdateUserProfile
 ): Promise<PostgrestError | null> {
-    const { data, error } = await supabase
+    const { error } = await supabase
         .from("profiles")
         .update({
             role: userDetails.role,
         })
-        .eq("user_id", userDetails.userId)
-        .select("profile_id:primary_key")
+        .eq("primary_key", userDetails.profileId)
         .single();
 
     const auditLog = {
@@ -32,12 +31,12 @@ export async function updateUserProfile(
             lastName: userDetails.lastName,
             phoneNumber: userDetails.phoneNumber,
         },
-        userId: userDetails.userId,
+        profileId: userDetails.profileId,
     };
 
     if (error) {
         const logId = await logErrorReturnLogId(
-            `Error with updating user profile: user id ${userDetails.userId}`,
+            `Error with updating profiles: profile id ${userDetails.profileId}`,
             {
                 error: error,
             }
@@ -46,6 +45,6 @@ export async function updateUserProfile(
         return error;
     }
 
-    await sendAuditLog({ ...auditLog, wasSuccess: true, profileId: data.profile_id });
+    await sendAuditLog({ ...auditLog, wasSuccess: true });
     return null;
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -9,7 +9,8 @@ export const revalidate = 0;
 
 export type DisplayedUserRole = UserRole | "UNKNOWN";
 export interface UserRow {
-    id: string;
+    userId: string;
+    profileId: string;
     firstName: string;
     lastName: string;
     userRole: DisplayedUserRole;

--- a/src/app/admin/usersTable/UsersTable.tsx
+++ b/src/app/admin/usersTable/UsersTable.tsx
@@ -22,7 +22,7 @@ import { getCurrentUser } from "@/server/getCurrentUser";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
 
 const usersTableHeaderKeysAndLabels: TableHeaders<UserRow> = [
-    ["id", "User ID"],
+    ["userId", "User ID"],
     ["firstName", "First Name"],
     ["lastName", "Last Name"],
     ["email", "Email"],
@@ -273,7 +273,7 @@ const UsersTable: React.FC = () => {
                 dataPortion={users}
                 headerKeysAndLabels={usersTableHeaderKeysAndLabels}
                 columnDisplayFunctions={userTableColumnDisplayFunctions}
-                toggleableHeaders={["id", "createdAt", "updatedAt"]}
+                toggleableHeaders={["userId", "createdAt", "updatedAt"]}
                 defaultShownHeaders={[
                     "firstName",
                     "lastName",
@@ -302,7 +302,7 @@ const UsersTable: React.FC = () => {
                     onDelete: userOnDelete,
                     onEdit: userOnEdit,
                     setDataPortion: setUsers,
-                    isDeletable: (row: UserRow) => row.id !== currentUserId,
+                    isDeletable: (row: UserRow) => row.userId !== currentUserId,
                 }}
                 filterConfig={{
                     primaryFiltersShown: true,

--- a/src/app/admin/usersTable/UsersTable.tsx
+++ b/src/app/admin/usersTable/UsersTable.tsx
@@ -162,18 +162,9 @@ const UsersTable: React.FC = () => {
                     method: emailSearch,
                 },
             }),
+            buildUserRoleFilter(),
         ];
 
-        const { data: userRoleFilter, error } = await buildUserRoleFilter();
-        if (error) {
-            switch (error.type) {
-                case "failedToFetchUserRoleFilterOptions":
-                    setErrorMessage(`Failed to retrieve user role filters. Log ID: ${error.logId}`);
-                    break;
-            }
-        } else {
-            filters.push(userRoleFilter);
-        }
         return filters;
     };
 

--- a/src/app/admin/usersTable/UsersTable.tsx
+++ b/src/app/admin/usersTable/UsersTable.tsx
@@ -133,7 +133,7 @@ const UsersTable: React.FC = () => {
         message: <></>,
     });
 
-    const buildFilters = async (): Promise<Filter<UserRow, any>[]> => {
+    const buildFilters = (): Filter<UserRow, any>[] => {
         const filters: Filter<UserRow, any>[] = [
             buildTextFilter({
                 key: "firstName",

--- a/src/app/admin/usersTable/getUsersData.ts
+++ b/src/app/admin/usersTable/getUsersData.ts
@@ -43,7 +43,7 @@ export const getUsersDataAndCount = async (
     sortState: SortState<UserRow>,
     abortSignal: AbortSignal
 ): Promise<GetUsersReturnType> => {
-    let query = supabase.from("profiles_plus").select("*");
+    let query = supabase.from("users_plus").select("*");
 
     if (
         sortState.sortEnabled &&
@@ -77,7 +77,8 @@ export const getUsersDataAndCount = async (
 
     const userData: UserRow[] = users.map((user) => {
         return {
-            id: user.user_id ?? "",
+            userId: user.user_id ?? "",
+            profileId: user.profile_id ?? "",
             firstName: user.first_name ?? "",
             lastName: user.last_name ?? "",
             userRole: user.role ?? "UNKNOWN",
@@ -105,7 +106,7 @@ const getUsersCount = async (
     filters: Filter<UserRow, any>[],
     abortSignal: AbortSignal
 ): Promise<GetUserCountReturnType> => {
-    let query = supabase.from("profiles_plus").select("*", { count: "exact", head: true });
+    let query = supabase.from("users_plus").select("*", { count: "exact", head: true });
 
     query = getQueryWithFiltersApplied(query, filters);
 

--- a/src/app/admin/usersTable/usersTableFilters.ts
+++ b/src/app/admin/usersTable/usersTableFilters.ts
@@ -2,22 +2,8 @@ import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 import { Database } from "@/databaseTypesFile";
 import { Filter, PaginationType } from "@/components/Tables/Filters";
 import { UserRow } from "@/app/admin/page";
-import supabase from "@/supabaseClient";
-import { logErrorReturnLogId } from "@/logger/logger";
 import { checklistFilter } from "@/components/Tables/ChecklistFilter";
 import { UserRole } from "@/databaseUtils";
-
-type BuildUserRoleFilterErrors = "failedToFetchUserRoleFilterOptions";
-
-type BuildUserRoleFilterAndError =
-    | {
-          data: Filter<UserRow, string[]>;
-          error: null;
-      }
-    | {
-          data: null;
-          error: { type: BuildUserRoleFilterErrors; logId: string };
-      };
 
 export const firstNameSearch = (
     query: PostgrestFilterBuilder<Database["public"], any, any>,
@@ -48,7 +34,7 @@ export const emailSearch = (
     return query.ilike("email", `%${state}%`);
 };
 
-export const buildUserRoleFilter = async (): Promise<BuildUserRoleFilterAndError> => {
+export const buildUserRoleFilter = (): Filter<UserRow, string[]> => {
     const userRoleSearch = (
         query: PostgrestFilterBuilder<Database["public"], any, any>,
         state: string[]
@@ -56,24 +42,15 @@ export const buildUserRoleFilter = async (): Promise<BuildUserRoleFilterAndError
         return query.in("role", state);
     };
 
-    const { data, error } = await supabase.from("profiles").select("role");
-
-    if (error) {
-        const logId = await logErrorReturnLogId("Error with fetch: User role filter options", {
-            error: error,
-        });
-        return { data: null, error: { type: "failedToFetchUserRoleFilterOptions", logId: logId } };
-    }
-
-    const userRolesFromDb: UserRole[] = data.map((row) => row.role) ?? [];
+    const allUserRoles: UserRole[] = ["volunteer", "manager", "staff", "admin"];
 
     const userRoleFilter = checklistFilter<UserRow>({
         key: "userRole",
         filterLabel: "User Role",
-        itemLabelsAndKeys: userRolesFromDb.map((userRole) => [userRole, userRole]),
-        initialCheckedKeys: userRolesFromDb,
+        itemLabelsAndKeys: allUserRoles.map((userRole) => [userRole, userRole]),
+        initialCheckedKeys: allUserRoles,
         methodConfig: { paginationType: PaginationType.Server, method: userRoleSearch },
     });
 
-    return { data: userRoleFilter, error: null };
+    return userRoleFilter;
 };

--- a/src/app/admin/usersTable/usersTableFilters.ts
+++ b/src/app/admin/usersTable/usersTableFilters.ts
@@ -67,15 +67,6 @@ export const buildUserRoleFilter = async (): Promise<BuildUserRoleFilterAndError
 
     const userRolesFromDb: UserRole[] = data.map((row) => row.role) ?? [];
 
-    const uniqueUserRoles = userRolesFromDb.reduce<UserRole[]>((accumulator, userRole) => {
-        if (!accumulator.includes(userRole)) {
-            accumulator.push(userRole);
-        }
-        return accumulator;
-    }, []);
-
-    uniqueUserRoles.sort();
-
     const userRoleFilter = checklistFilter<UserRow>({
         key: "userRole",
         filterLabel: "User Role",

--- a/src/app/admin/usersTable/usersTableFilters.ts
+++ b/src/app/admin/usersTable/usersTableFilters.ts
@@ -79,8 +79,8 @@ export const buildUserRoleFilter = async (): Promise<BuildUserRoleFilterAndError
     const userRoleFilter = checklistFilter<UserRow>({
         key: "userRole",
         filterLabel: "User Role",
-        itemLabelsAndKeys: uniqueUserRoles.map((userRole) => [userRole, userRole]),
-        initialCheckedKeys: uniqueUserRoles,
+        itemLabelsAndKeys: userRolesFromDb.map((userRole) => [userRole, userRole]),
+        initialCheckedKeys: userRolesFromDb,
         methodConfig: { paginationType: PaginationType.Server, method: userRoleSearch },
     });
 

--- a/src/databaseTypesFile.ts
+++ b/src/databaseTypesFile.ts
@@ -76,6 +76,13 @@ export type Database = {
             referencedColumns: ["primary_key"]
           },
           {
+            foreignKeyName: "audit_log_actor_profile_id_fkey"
+            columns: ["actor_profile_id"]
+            isOneToOne: false
+            referencedRelation: "users_plus"
+            referencedColumns: ["profile_id"]
+          },
+          {
             foreignKeyName: "audit_log_client_id_fkey"
             columns: ["client_id"]
             isOneToOne: false
@@ -620,15 +627,15 @@ export type Database = {
             foreignKeyName: "profiles_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: true
-            referencedRelation: "profiles_plus"
-            referencedColumns: ["user_id"]
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
             foreignKeyName: "profiles_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: "users_plus"
+            referencedColumns: ["user_id"]
           },
         ]
       }
@@ -669,6 +676,7 @@ export type Database = {
           action: string | null
           actor_name: string | null
           actor_profile_id: string | null
+          actor_role: Database["public"]["Enums"]["role"] | null
           actor_user_id: string | null
           client_id: string | null
           collection_centre_id: string | null
@@ -693,6 +701,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "profiles"
             referencedColumns: ["primary_key"]
+          },
+          {
+            foreignKeyName: "audit_log_actor_profile_id_fkey"
+            columns: ["actor_profile_id"]
+            isOneToOne: false
+            referencedRelation: "users_plus"
+            referencedColumns: ["profile_id"]
           },
           {
             foreignKeyName: "audit_log_client_id_fkey"
@@ -796,7 +811,7 @@ export type Database = {
             foreignKeyName: "profiles_user_id_fkey"
             columns: ["actor_user_id"]
             isOneToOne: true
-            referencedRelation: "profiles_plus"
+            referencedRelation: "users_plus"
             referencedColumns: ["user_id"]
           },
         ]
@@ -869,12 +884,13 @@ export type Database = {
           },
         ]
       }
-      profiles_plus: {
+      users_plus: {
         Row: {
           created_at: string | null
           email: string | null
           first_name: string | null
           last_name: string | null
+          profile_id: string | null
           role: Database["public"]["Enums"]["role"] | null
           telephone_number: string | null
           updated_at: string | null

--- a/supabase/migrations/20240430155721_rename_profiles_plus_to_users_plus_and_include_profile_id.sql
+++ b/supabase/migrations/20240430155721_rename_profiles_plus_to_users_plus_and_include_profile_id.sql
@@ -1,0 +1,42 @@
+drop view if exists "public"."profiles_plus";
+
+create or replace view "public"."users_plus" as  SELECT users.id AS user_id,
+    users.email,
+    users.created_at,
+    users.updated_at,
+    profiles.primary_key AS profile_id,
+    profiles.first_name,
+    profiles.last_name,
+    profiles.role,
+    profiles.telephone_number
+   FROM (auth.users
+     LEFT JOIN profiles ON ((users.id = profiles.user_id)))
+  ORDER BY profiles.first_name;
+
+
+create or replace view "public"."audit_log_plus" as  SELECT audit_log.action,
+    audit_log.actor_profile_id,
+    audit_log.client_id,
+    audit_log.collection_centre_id,
+    audit_log.content,
+    audit_log.created_at,
+    audit_log.event_id,
+    audit_log.list_hotel_id,
+    audit_log.list_id,
+    audit_log.log_id,
+    audit_log.packing_slot_id,
+    audit_log.parcel_id,
+    audit_log.primary_key,
+    audit_log.profile_id,
+    audit_log.status_order,
+    audit_log."wasSuccess",
+    audit_log.website_data,
+    concat(profiles.first_name, ' ', profiles.last_name) AS actor_name,
+    profiles.user_id AS actor_user_id,
+    profiles.role AS actor_role
+   FROM (audit_log
+     LEFT JOIN profiles ON ((audit_log.actor_profile_id = profiles.primary_key)))
+  ORDER BY audit_log.created_at;
+
+
+


### PR DESCRIPTION
## What's changed

- Audit log editing a user - currently only role changes are possible in the front end but the audit log logic will extend to any changes.
- Also fixed a bug where when you change a users role to one that was not previously held by any user, the user disappears from the users table until refreshing. Fixed this by filtering by all user roles not just those held by users in the DB. 

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [x] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - NO
  - [x] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.