### PR TITLE
VFB-205: Fix profile name sort, display role of deleted users, display NFA in parcel link if applicable

### DIFF
--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Parcel.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Parcel.tsx
@@ -4,7 +4,6 @@ import React from "react";
 import supabase from "@/supabaseClient";
 import { logErrorReturnLogId } from "@/logger/logger";
 import LinkButton from "@/components/Buttons/LinkButton";
-import dayjs from "dayjs";
 import AuditLogModalRow from "../AuditLogModalRow";
 import { AuditLogModalRowResponse } from "../types";
 import { getParcelOverviewString } from "@/common/format";

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Parcel.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Parcel.tsx
@@ -7,6 +7,7 @@ import LinkButton from "@/components/Buttons/LinkButton";
 import dayjs from "dayjs";
 import AuditLogModalRow from "../AuditLogModalRow";
 import { AuditLogModalRowResponse } from "../types";
+import { getParcelOverviewString } from "@/common/format";
 
 interface ParcelLinkDetails {
     parcelId: string;
@@ -79,9 +80,7 @@ const ParcelLink: React.FC<ParcelLinkDetails> = ({
     collectionDatetime,
 }) => (
     <LinkButton link={`/parcels?parcelId=${parcelId}`}>
-        {addressPostcode}
-        {fullName && ` - ${fullName}`}
-        {collectionDatetime && ` @ ${dayjs(collectionDatetime!).format("DD/MM/YYYY HH:mm")}`}
+        {getParcelOverviewString(addressPostcode, fullName, collectionDatetime)}
     </LinkButton>
 );
 

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Profile.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Profile.tsx
@@ -6,11 +6,13 @@ import { logErrorReturnLogId } from "@/logger/logger";
 import AuditLogModalRow, { TextValueContainer } from "../AuditLogModalRow";
 import { AuditLogModalRowResponse } from "../types";
 import { profileDisplayNameForDeletedUser } from "../../format";
+import { UserRole } from "@/databaseUtils";
 
 interface ProfileNameDetails {
     firstName: string;
     lastName: string;
     userId: string | null;
+    role: UserRole;
 }
 
 type ProfileNameErrorType = "failedProfileFetch";
@@ -24,7 +26,7 @@ const getProfileNameOrErrorMessage = async (
 ): Promise<AuditLogModalRowResponse<ProfileNameDetails>> => {
     const { data: data, error } = await supabase
         .from("profiles")
-        .select("primary_key, first_name, last_name, user_id")
+        .select("primary_key, first_name, last_name, user_id, role")
         .eq("primary_key", profileId)
         .single();
 
@@ -43,6 +45,7 @@ const getProfileNameOrErrorMessage = async (
             firstName: data.first_name ?? "",
             lastName: data.last_name ?? "",
             userId: data.user_id,
+            role: data.role
         },
         errorMessage: null,
     };
@@ -58,9 +61,9 @@ const getErrorMessage = (error: ProfileNameError): string => {
     return `${errorMessage} Log ID: ${error.logId}`;
 };
 
-const ProfileName: React.FC<ProfileNameDetails> = ({ firstName, lastName, userId }) => (
+const ProfileName: React.FC<ProfileNameDetails> = ({ firstName, lastName, userId, role }) => (
     <TextValueContainer>
-        {userId === null ? profileDisplayNameForDeletedUser : `${firstName} ${lastName}`}
+        {userId === null ? profileDisplayNameForDeletedUser(role) : `${firstName} ${lastName}`}
     </TextValueContainer>
 );
 

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Profile.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Profile.tsx
@@ -45,7 +45,7 @@ const getProfileNameOrErrorMessage = async (
             firstName: data.first_name ?? "",
             lastName: data.last_name ?? "",
             userId: data.user_id,
-            role: data.role
+            role: data.role,
         },
         errorMessage: null,
     };

--- a/src/app/admin/auditLogTable/fetchAuditLogData.ts
+++ b/src/app/admin/auditLogTable/fetchAuditLogData.ts
@@ -57,7 +57,6 @@ export const fetchAuditLog = async (
         const logId = await logErrorReturnLogId("Error with fetch: Audit Log", {
             error: error,
         });
-        console.error(error);
         return { data: null, error: { type: "failedAuditLogFetch", logId: logId } };
     }
 

--- a/src/app/admin/auditLogTable/fetchAuditLogData.ts
+++ b/src/app/admin/auditLogTable/fetchAuditLogData.ts
@@ -57,7 +57,7 @@ export const fetchAuditLog = async (
         const logId = await logErrorReturnLogId("Error with fetch: Audit Log", {
             error: error,
         });
-        console.error(error)
+        console.error(error);
         return { data: null, error: { type: "failedAuditLogFetch", logId: logId } };
     }
 

--- a/src/app/admin/auditLogTable/fetchAuditLogData.ts
+++ b/src/app/admin/auditLogTable/fetchAuditLogData.ts
@@ -57,6 +57,7 @@ export const fetchAuditLog = async (
         const logId = await logErrorReturnLogId("Error with fetch: Audit Log", {
             error: error,
         });
+        console.error(error)
         return { data: null, error: { type: "failedAuditLogFetch", logId: logId } };
     }
 

--- a/src/app/admin/auditLogTable/format.ts
+++ b/src/app/admin/auditLogTable/format.ts
@@ -22,4 +22,5 @@ export const getAuditLogErrorMessage = (error: AuditLogError | AuditLogCountErro
     return `${errorMessage} Log ID: ${error.logId}`;
 };
 
-export const profileDisplayNameForDeletedUser = (role: UserRole | null) => `Deleted User ${role && `- ${capitaliseWords(role)}`}`;
+export const profileDisplayNameForDeletedUser = (role: UserRole | null): string =>
+    `Deleted User ${role && `- ${capitaliseWords(role)}`}`;

--- a/src/app/admin/auditLogTable/format.ts
+++ b/src/app/admin/auditLogTable/format.ts
@@ -1,5 +1,6 @@
-import { formatBooleanOrNull, formatDateTime } from "@/common/format";
+import { capitaliseWords, formatBooleanOrNull, formatDateTime } from "@/common/format";
 import { AuditLogCountError, AuditLogError } from "./fetchAuditLogData";
+import { UserRole } from "@/databaseUtils";
 
 export const auditLogTableColumnDisplayFunctions = {
     createdAt: formatDateTime,
@@ -21,4 +22,4 @@ export const getAuditLogErrorMessage = (error: AuditLogError | AuditLogCountErro
     return `${errorMessage} Log ID: ${error.logId}`;
 };
 
-export const profileDisplayNameForDeletedUser = "Deleted User";
+export const profileDisplayNameForDeletedUser = (role: UserRole | null) => `Deleted User ${role && `- ${capitaliseWords(role)}`}`;

--- a/src/app/admin/auditLogTable/sortFunctions.ts
+++ b/src/app/admin/auditLogTable/sortFunctions.ts
@@ -23,7 +23,7 @@ export const auditLogTableSortableColumns: SortOptions<AuditLogRow>[] = [
         key: "actorName",
         sortMethodConfig: {
             method: (query, sortDirection) =>
-                query.order("actor_profile_name", { ascending: sortDirection === "asc" }),
+                query.order("actor_name", { ascending: sortDirection === "asc" }),
             paginationType: PaginationType.Server,
         },
     },

--- a/src/app/admin/auditLogTable/types.ts
+++ b/src/app/admin/auditLogTable/types.ts
@@ -30,7 +30,7 @@ export const convertAuditLogPlusRowsToAuditLogRows = (
         action: auditLogPlusRow.action ?? "",
         actorName:
             auditLogPlusRow.actor_user_id === null
-                ? profileDisplayNameForDeletedUser
+                ? profileDisplayNameForDeletedUser(auditLogPlusRow.actor_role)
                 : auditLogPlusRow.actor_name ?? "",
         clientId: auditLogPlusRow.client_id ?? "",
         collectionCentreId: auditLogPlusRow.collection_centre_id ?? "",

--- a/src/app/parcels/ActionBar/SelectedParcelsOverview.tsx
+++ b/src/app/parcels/ActionBar/SelectedParcelsOverview.tsx
@@ -2,7 +2,7 @@ import { ParcelsTableRow } from "../getParcelsTableData";
 import styled from "styled-components";
 import React from "react";
 import dayjs from "dayjs";
-import { nullPostcodeDisplay } from "../../../common/format";
+import { getParcelOverviewString, nullPostcodeDisplay } from "../../../common/format";
 
 const Heading = styled.div`
     font-size: 1.2rem;
@@ -30,10 +30,7 @@ const SelectedParcelsOverview: React.FC<ShowParcelsProps> = (props) => {
             <Heading>{props.parcels.length === 1 ? "Parcel" : "Parcels"} selected:</Heading>
             {props.parcels.slice(0, props.maxParcelsToShow).map((parcel) => (
                 <ListItem key={parcel.parcelId}>
-                    {parcel.addressPostcode ?? nullPostcodeDisplay}
-                    {parcel.fullName && ` - ${parcel.fullName}`}
-                    {parcel.collectionDatetime &&
-                        ` @ ${dayjs(parcel.collectionDatetime!).format("DD/MM/YYYY HH:mm")}`}
+                    {getParcelOverviewString(parcel.addressPostcode, parcel.fullName, parcel.collectionDatetime)}
                 </ListItem>
             ))}
             {props.parcels.length > props.maxParcelsToShow && <ListItem emphasised>...</ListItem>}

--- a/src/app/parcels/ActionBar/SelectedParcelsOverview.tsx
+++ b/src/app/parcels/ActionBar/SelectedParcelsOverview.tsx
@@ -1,8 +1,7 @@
 import { ParcelsTableRow } from "../getParcelsTableData";
 import styled from "styled-components";
 import React from "react";
-import dayjs from "dayjs";
-import { getParcelOverviewString, nullPostcodeDisplay } from "../../../common/format";
+import { getParcelOverviewString } from "../../../common/format";
 
 const Heading = styled.div`
     font-size: 1.2rem;
@@ -30,7 +29,11 @@ const SelectedParcelsOverview: React.FC<ShowParcelsProps> = (props) => {
             <Heading>{props.parcels.length === 1 ? "Parcel" : "Parcels"} selected:</Heading>
             {props.parcels.slice(0, props.maxParcelsToShow).map((parcel) => (
                 <ListItem key={parcel.parcelId}>
-                    {getParcelOverviewString(parcel.addressPostcode, parcel.fullName, parcel.collectionDatetime)}
+                    {getParcelOverviewString(
+                        parcel.addressPostcode,
+                        parcel.fullName,
+                        parcel.collectionDatetime
+                    )}
                 </ListItem>
             ))}
             {props.parcels.length > props.maxParcelsToShow && <ListItem emphasised>...</ListItem>}

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -71,6 +71,6 @@ export const getParcelOverviewString = (
     fullName: string,
     collectionDatetime: Date | null
 ): string =>
-    `${addressPostcode ?? nullPostcodeDisplay}${fullName && ` - ${fullName}`}${
-        collectionDatetime && ` @ ${dayjs(collectionDatetime!).format("DD/MM/YYYY HH:mm")}`
-    }`;
+    (addressPostcode ?? nullPostcodeDisplay) +
+    (fullName && ` - ${fullName}`) +
+    (collectionDatetime && ` @ ${dayjs(collectionDatetime).format("DD/MM/YYYY HH:mm")}`);

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -1,5 +1,5 @@
 import { Json } from "@/databaseTypesFile";
-import { Dayjs } from "dayjs";
+import dayjs, { Dayjs } from "dayjs";
 
 export const nullPostcodeDisplay = "NFA";
 
@@ -65,3 +65,6 @@ export const getReadableWebsiteDataName = (name: string): string =>
         .split("_")
         .map((word) => `${word[0].toUpperCase()}${word.slice(1)}`)
         .join(" ");
+
+export const getParcelOverviewString = (addressPostcode: string | null, fullName: string, collectionDatetime: Date | null): string => `${addressPostcode ?? nullPostcodeDisplay}${fullName && ` - ${fullName}`}${collectionDatetime &&
+    ` @ ${dayjs(collectionDatetime!).format("DD/MM/YYYY HH:mm")}`}`

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -66,5 +66,11 @@ export const getReadableWebsiteDataName = (name: string): string =>
         .map((word) => `${word[0].toUpperCase()}${word.slice(1)}`)
         .join(" ");
 
-export const getParcelOverviewString = (addressPostcode: string | null, fullName: string, collectionDatetime: Date | null): string => `${addressPostcode ?? nullPostcodeDisplay}${fullName && ` - ${fullName}`}${collectionDatetime &&
-    ` @ ${dayjs(collectionDatetime!).format("DD/MM/YYYY HH:mm")}`}`
+export const getParcelOverviewString = (
+    addressPostcode: string | null,
+    fullName: string,
+    collectionDatetime: Date | null
+): string =>
+    `${addressPostcode ?? nullPostcodeDisplay}${fullName && ` - ${fullName}`}${
+        collectionDatetime && ` @ ${dayjs(collectionDatetime!).format("DD/MM/YYYY HH:mm")}`
+    }`;

--- a/src/databaseTypesFile.ts
+++ b/src/databaseTypesFile.ts
@@ -669,6 +669,7 @@ export type Database = {
           action: string | null
           actor_name: string | null
           actor_profile_id: string | null
+          actor_role: Database["public"]["Enums"]["role"] | null
           actor_user_id: string | null
           client_id: string | null
           collection_centre_id: string | null

--- a/supabase/migrations/20240430152259_add_actor_role_to_audit_log_plus.sql
+++ b/supabase/migrations/20240430152259_add_actor_role_to_audit_log_plus.sql
@@ -1,0 +1,26 @@
+create or replace view "public"."audit_log_plus" as  SELECT audit_log.action,
+    audit_log.actor_profile_id,
+    audit_log.client_id,
+    audit_log.collection_centre_id,
+    audit_log.content,
+    audit_log.created_at,
+    audit_log.event_id,
+    audit_log.list_hotel_id,
+    audit_log.list_id,
+    audit_log.log_id,
+    audit_log.packing_slot_id,
+    audit_log.parcel_id,
+    audit_log.primary_key,
+    audit_log.profile_id,
+    audit_log.status_order,
+    audit_log."wasSuccess",
+    audit_log.website_data,
+    concat(profiles.first_name, ' ', profiles.last_name) AS actor_name,
+    profiles.user_id AS actor_user_id,
+    profiles.role AS actor_role
+   FROM (audit_log
+     LEFT JOIN profiles ON ((audit_log.actor_profile_id = profiles.primary_key)))
+  ORDER BY audit_log.created_at;
+
+
+


### PR DESCRIPTION
## What's changed

Fix for VFB-205 Audit log modal.
- Fix profile name sort, which was showing an error in front end
- Display role of deleted users in both audit log row and modal
- Display NFA in parcel link within audit log modal if applicable

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [x] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - NO
  - [x] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
