### PR TITLE
VFB-210: Audit log list order change

### DIFF
--- a/src/app/lists/ListDataview.tsx
+++ b/src/app/lists/ListDataview.tsx
@@ -184,7 +184,7 @@ const ListsDataView: React.FC<ListDataViewProps> = ({
         ]);
 
         const auditLog = {
-            action: "move a list item",
+            action: `move a list item ${row1.rowOrder <= row2.rowOrder ? "down" : "up"}`,
             listId: row1.primaryKey,
             content: {
                 itemName: row1.itemName,


### PR DESCRIPTION
## What's changed
Send an audit log when a list item is moved up or down.

Please note: I decided to only send an audit log for the list item that was clicked, so that we have one audit log per list item order change, to be consistent with packing slots. (Opposed to two audit logs, one for each list item that moves - the one that is clicked and the one that it swaps with).

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

No DB changes.
