### PR TITLE
Add hint to first time setup to log in to snaplet

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ have been delivered to clients.
 
 * Download .env.local (Local) from Keeper and put in the top-level directory as `.env.local`. Check that this file has NEXT_PUBLIC_SUPABASE_URL set to http://127.0.0.1:54321.
 
-* Use `npm run post_checkout` to install any dependencies.
+* Use `npm run post_checkout` to install any dependencies. (You may need to log in to snaplet first: `npx snaplet auth setup`).
 
 * If you're using WSL, you need to download some dependencies for Cypress:
 ```shell


### PR DESCRIPTION
## What's changed
First time users may need to log in to snaplet before running the post_checkout script, so added a hint to the readme for this.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| paste_here | paste_here |

## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [ ] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
