### PR TITLE
#232: Use en-GB locale for calendar

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -252,11 +252,6 @@ const Calendar: React.FC<CalendarProps> = ({
                     initialDate={initialDate}
                     views={{
                         dayGridMonth: {
-                            eventTimeFormat: {
-                                hour: "numeric",
-                                minute: "2-digit",
-                                meridiem: "short",
-                            },
                             titleFormat: { year: "numeric", month: "short" },
                             dayMaxEventRows: 3,
                             moreLinkClick: "day",
@@ -268,11 +263,6 @@ const Calendar: React.FC<CalendarProps> = ({
                             slotMaxTime: calendarEndTime,
                         },
                         timeGridDay: {
-                            eventTimeFormat: {
-                                hour: "numeric",
-                                minute: "2-digit",
-                                meridiem: "short",
-                            },
                             titleFormat: { year: "numeric", month: "short", day: "numeric" },
                             slotMinTime: calendarStartTime,
                             slotMaxTime: calendarEndTime,
@@ -282,6 +272,17 @@ const Calendar: React.FC<CalendarProps> = ({
                     height="auto"
                     eventDisplay="block"
                     locale={enGbLocale}
+                    eventTimeFormat={{
+                        hour: "numeric",
+                        minute: "2-digit",
+                        meridiem: "short",
+                        hour12: true,
+                    }}
+                    slotLabelFormat={{
+                        hour: "numeric",
+                        meridiem: "short",
+                        hour12: true,
+                    }}
                 />
             </CalendarStyling>
         </>

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -10,6 +10,7 @@ import styled from "styled-components";
 import EventModal from "@/components/Calendar/EventModal";
 import { Paper } from "@mui/material";
 import CalendarFilters from "@/components/Calendar/Filters";
+import enGbLocale from "@fullcalendar/core/locales/en-gb";
 
 export interface CalendarProps {
     initialEvents: CalendarEvent[];
@@ -280,6 +281,7 @@ const Calendar: React.FC<CalendarProps> = ({
                     eventInteractive={true}
                     height="auto"
                     eventDisplay="block"
+                    locale={enGbLocale}
                 />
             </CalendarStyling>
         </>


### PR DESCRIPTION
## What's changed
* Set the calendar to use en-GB locale so that the date is formatted correctly (day/month).
  * This also makes Monday the first day of the week
* Kept the times as 12h (this overrides the locale defaults)
* Also extracted the `eventTimeFormat` specification to apply to all views because this was duplicated


## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://private-user-images.githubusercontent.com/80202270/319672080-f42f37c8-79fb-4adf-99c8-e310d1a4d99f.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTQ2NDQ3NDYsIm5iZiI6MTcxNDY0NDQ0NiwicGF0aCI6Ii84MDIwMjI3MC8zMTk2NzIwODAtZjQyZjM3YzgtNzlmYi00YWRmLTk5YzgtZTMxMGQxYTRkOTlmLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA1MDIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNTAyVDEwMDcyNlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTIwMDNlZjFjZDNmZWNkMTc0MzE3Nzk1YTA2ZTlmZmQzMDBkMGRhNjg1ZDNkZGEwZTJkMDVmZjJmMDIzOWQyNjYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.G7aMek82wLvaB399u3sIW8uEB2AKboK5BDqtzRtDpMU) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985147/b0f1359f-267e-4ca7-a098-4c37190f37cb) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

No database changes