### PR TITLE
#181: Driver name should be mandatory field

### DIFF
--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -32,7 +32,7 @@ const DriverOverviewInput: React.FC<DriverOverviewInputProps> = ({
     return (
         <>
             <Heading>Delivery Information</Heading>
-            <FreeFormTextInput onChange={onDriverNameChange} label="Driver's Name" />
+            <FreeFormTextInput onChange={onDriverNameChange} label="Driver's Name (required)" />
             <DatePicker
                 defaultValue={dayjs()}
                 onChange={onDateChange}

--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -75,6 +75,8 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
 
     const [isDateValid, setIsDateValid] = useState(true);
 
+    const isInputValid = isDateValid && driverName.length > 0;
+
     const onDriverNameChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
         setDriverName(event.target.value);
     };
@@ -136,7 +138,7 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
                     driverName={driverName}
                     onPdfCreationCompleted={onPdfCreationCompleted}
                     onPdfCreationFailed={onPdfCreationFailed}
-                    disabled={!isDateValid}
+                    disabled={!isInputValid}
                 />
             }
             contentAboveButton={

--- a/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
@@ -22,7 +22,11 @@ const ShippingLabelsInput: React.FC<ShippingLabelsInputProps> = ({ onLabelQuanti
     return (
         <>
             <Heading>Shipping Labels</Heading>
-            <FreeFormTextInput type="number" onChange={onLabelQuantityChange} label="Quantity" />
+            <FreeFormTextInput
+                type="number"
+                onChange={onLabelQuantityChange}
+                label="Quantity (required)"
+            />
         </>
     );
 };


### PR DESCRIPTION
## What's changed
Disable submit button when creating driver overview pdf when driver name is blank.
(Followed approach in ShippingLabelModal)

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985147/e6e1509b-fbab-4270-ab3c-b06f47deee88) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985147/ca3354c3-94e8-41f0-8fe9-c845026b8a83) ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985147/fe5a9433-a4c0-458a-bcd7-f6eeba2b293f) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

no db changes
