### PR TITLE
#184: Changed Label to Parcel on shipping label

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "db:local:generate_types": "supabase gen types typescript --local --schema public > src/databaseTypesFile.ts",
     "db:remote:generate_types": "supabase gen types typescript --schema public > src/databaseTypesFile.ts",
     "db:generate_seed": "npx tsx supabase/seed/seed.mts > supabase/seed.sql",
-    "post_checkout": "npm install && npx supabase stop && npx supabase start && npm run dev:reset_supabase && npx snaplet generate"
+    "post_checkout": "npm install && npx supabase start && npm run dev:reset_supabase && npx snaplet generate"
   },
   "nyc": {
     "all": true,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "db:local:generate_types": "supabase gen types typescript --local --schema public > src/databaseTypesFile.ts",
     "db:remote:generate_types": "supabase gen types typescript --schema public > src/databaseTypesFile.ts",
     "db:generate_seed": "npx tsx supabase/seed/seed.mts > supabase/seed.sql",
-    "post_checkout": "npm install && npx supabase start && npm run dev:reset_supabase && npx snaplet generate"
+    "post_checkout": "npm install && npx supabase stop && npx supabase start && npm run dev:reset_supabase && npx snaplet generate"
   },
   "nyc": {
     "all": true,

--- a/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
+++ b/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
@@ -144,7 +144,7 @@ const SingleLabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) =>
                     </View>
                     <View style={[styles.rightCol, styles.bottomAlign]}>
                         <Text style={styles.mediumText}>
-                            Label {index + 1} of {quantity}
+                            Parcel {index + 1} of {quantity}
                         </Text>
                     </View>
                 </View>


### PR DESCRIPTION
## What's changed
The shipping label shows Parcel instead of Label

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![327413663-9436a69c-ccd1-4da8-91f2-71530b1399c1](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167894215/09de5aac-b665-4176-bb45-30d027ad2bdb) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167894215/46922cad-2140-48cd-b37a-8a5c092c87e7) |


## Checklist
- [x ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x ] I have documented the testing steps for QA
- [x ] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x ] Make sure you've verified it works via `npm run build` and `npm run start`
- [x ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x ] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [ ] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - YES / NO (remove as appropriate)
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
