### PR TITLE
#208: Removed logout button on forgot password page

### DIFF
--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -111,7 +111,7 @@ const CenteredDiv = styled.div`
 
 const LoginDependent: React.FC<Props> = (props) => {
     const pathname = usePathname();
-    if (pathname === "/login") {
+    if (pathname === "/login" || pathname === "/forgot-password") {
         return <></>;
     }
     return <>{props.children}</>;


### PR DESCRIPTION
## What's changed

- Removed logout button on forgot password page

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985277/449181f9-4774-4480-b76f-53cd47b4edb7) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985277/223eb776-054a-4335-847f-b61a3284ac36) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... (no changes made)
