### PR TITLE
VFB-181: Remove duplicate postcodes from Google Map generation

### DIFF
--- a/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
@@ -25,16 +25,19 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
         setActionCompleted(true);
     };
 
-    const formattedPostcodes = Array.from(
-        props.selectedParcels.reduce<Set<string>>((formattedPostcodes, parcel) => {
+    const formattedPostcodes = props.selectedParcels.reduce<string[]>(
+        (formattedPostcodes, parcel) => {
             if (parcel.addressPostcode) {
-                formattedPostcodes.add(parcel.addressPostcode.replaceAll(" ", ""));
+                formattedPostcodes.push(parcel.addressPostcode.replaceAll(" ", ""));
             }
             return formattedPostcodes;
-        }, new Set())
+        },
+        []
     );
 
-    const mapsLinkForSelectedParcels = `https://www.google.com/maps/dir/${formattedPostcodes.join("/")}//`;
+    const uniquePostcodes = Array.from(new Set(formattedPostcodes));
+
+    const mapsLinkForSelectedParcels = `https://www.google.com/maps/dir/${uniquePostcodes.join("/")}//`;
 
     return (
         <GeneralActionModal
@@ -47,7 +50,7 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
                 <Button
                     variant="contained"
                     onClick={() => {
-                        if (formattedPostcodes.length === 0) {
+                        if (uniquePostcodes.length === 0) {
                             setErrorMessage("No selected parcels have addresses.");
                             setActionCompleted(true);
                             return;

--- a/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
@@ -35,7 +35,7 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
     );
 
     const mapsLinkForSelectedParcels =
-        "https://www.google.com/maps/dir/" + formattedPostcodes.join("/");
+        "https://www.google.com/maps/dir/" + formattedPostcodes.join("/") + "//";
 
     return (
         <GeneralActionModal

--- a/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
@@ -34,8 +34,7 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
         }, new Set())
     );
 
-    const mapsLinkForSelectedParcels =
-        "https://www.google.com/maps/dir/" + formattedPostcodes.join("/") + "//";
+    const mapsLinkForSelectedParcels = `https://www.google.com/maps/dir/${formattedPostcodes.join("/")}//`;
 
     return (
         <GeneralActionModal

--- a/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
@@ -25,18 +25,17 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
         setActionCompleted(true);
     };
 
-    const formattedPostcodes = props.selectedParcels.reduce<string[]>(
-        (formattedPostcodes, parcel) => {
+    const formattedPostcodes = Array.from(
+        props.selectedParcels.reduce<Set<string>>((formattedPostcodes, parcel) => {
             if (parcel.addressPostcode) {
-                formattedPostcodes.push(parcel.addressPostcode.replaceAll(" ", ""));
+                formattedPostcodes.add(parcel.addressPostcode.replaceAll(" ", ""));
             }
             return formattedPostcodes;
-        },
-        []
+        }, new Set())
     );
+
     const mapsLinkForSelectedParcels =
         "https://www.google.com/maps/dir/" + formattedPostcodes.join("/");
-    ("//");
 
     return (
         <GeneralActionModal


### PR DESCRIPTION
## What's changed
* Removed duplicate postcodes
* Appended `//` to URL to avoid generating route

(Unable to reproduce the bug where the generation fails the first time.)

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985147/327025db-ba3f-4cf3-9903-8136cdc86fd5) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985147/7e76816a-c23d-4f08-86a3-5d9825df9189) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

no db changes
