### PR TITLE
VFB-168: Change policy for status order table to authenticated only

### DIFF
--- a/supabase/migrations/20240513142439_change_rld_policy_for_status_order_table.sql
+++ b/supabase/migrations/20240513142439_change_rld_policy_for_status_order_table.sql
@@ -1,0 +1,11 @@
+drop policy "Enable read access for all users" on "public"."status_order";
+
+create policy "Enable read access for all users"
+on "public"."status_order"
+as permissive
+for select
+to authenticated
+using (true);
+
+
+


### PR DESCRIPTION
## What's changed
Changed rls policy for status order table to authenticated only

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| paste_here | paste_here |

## Checklist
- [] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [ ] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `db:local:generate_types`
  - [x] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - NO (remove as appropriate)
  - [x] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
