### PR TITLE
Vfb 130 improving shipping label layout

### DIFF
--- a/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
+++ b/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
@@ -24,18 +24,17 @@ export interface ShippingLabelData {
 }
 
 const mmToPixels = (mm: number): number => {
-    const inches = mm / 2.54
-    const pixelsPerCm = 21.285;
-    return mm * pixelsPerCm;
+    const pixelsPerMmAt72Dpi = 72 / 25.4;
+    return mm * pixelsPerMmAt72Dpi;
 };
 
-const labelSizePixels = { width: mmToPixels(20), height: mmToPixels(6.2) };
+const labelSizePixels = { width: mmToPixels(200), height: mmToPixels(62) };
 
 const styles = StyleSheet.create({
     page: {
         padding: "0.2cm",
         fontFamily: "Helvetica",
-        fontSize: "10pt",
+        fontSize: "11pt",
         lineHeight: 1.25,
     },
     cardWrapper: {
@@ -62,14 +61,14 @@ const styles = StyleSheet.create({
     leftCol: { flexBasis: "32%", textAlign: "left" },
     middleCol: { flex: 1, textAlign: "left" },
     rightCol: { flexBasis: "28%", textAlign: "right"},
-    bottomAlign: { marginTop: "13px"},
+    bottomAlign: { marginTop: "21px"},
     headingText: { fontFamily: "Helvetica-Bold", textTransform: "uppercase" },
     largeText: {
-        fontSize: "20pt",
+        fontSize: "26pt",
         lineHeight: 1,
     },
     mediumText: {
-        fontSize: "15pt",
+        fontSize: "19pt",
         lineHeight: 1,
     },
 });
@@ -129,7 +128,7 @@ const SingleLabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) =>
                     </View>
                 </View>
                 <View style={[styles.bottomRow]}>
-                    <View style={[styles.leftCol, {marginTop: "10px"}]}>
+                    <View style={[styles.leftCol, {marginTop: "15px"}]}>
                         <Text style={styles.largeText}>
                             {data.address_postcode ?? nullPostcodeDisplay}
                         </Text>
@@ -141,7 +140,7 @@ const SingleLabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) =>
                             </Text>
                         </View>
                         <View style = {{marginTop: "auto"}}>
-                            <Text style={{fontWeight: "bold", fontSize: "20pt"}}>|</Text>
+                            <Text style={{fontWeight: "bold", fontSize: "25pt"}}>|</Text>
                         </View>
                         <View style = {[styles.bottomAlign, { flexDirection: "row" }]}>
                             <Text style={styles.mediumText}>

--- a/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
+++ b/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
 import { nullPostcodeDisplay } from "@/common/format";
-import { faBuildingCircleArrowRight, faTruck } from "@fortawesome/free-solid-svg-icons";
+import { faCalendarXmark, faShoePrints, faTruck } from "@fortawesome/free-solid-svg-icons";
 import FontAwesomeIconPdfComponent from "@/pdf/FontAwesomeIconPdfComponent";
+import { AlignHorizontalLeft } from "@mui/icons-material";
 
 export interface ShippingLabelData {
     label_quantity: number;
@@ -23,17 +24,18 @@ export interface ShippingLabelData {
 }
 
 const mmToPixels = (mm: number): number => {
-    const pixelsPerMmAt72Dpi = 72 / 25.4;
-    return mm * pixelsPerMmAt72Dpi;
+    const inches = mm / 2.54
+    const pixelsPerCm = 21.285;
+    return mm * pixelsPerCm;
 };
 
-const labelSizePixels = { width: mmToPixels(150), height: mmToPixels(62) };
+const labelSizePixels = { width: mmToPixels(20), height: mmToPixels(6.2) };
 
 const styles = StyleSheet.create({
     page: {
         padding: "0.2cm",
         fontFamily: "Helvetica",
-        fontSize: "11pt",
+        fontSize: "10pt",
         lineHeight: 1.25,
     },
     cardWrapper: {
@@ -44,7 +46,7 @@ const styles = StyleSheet.create({
         padding: "0.2cm",
     },
     topRow: {
-        justifyContent: "flex-start",
+        justifyContent: "space-between",
         flexBasis: "20%",
         display: "flex",
         flexDirection: "row",
@@ -52,22 +54,22 @@ const styles = StyleSheet.create({
     },
     middleRow: { flex: 1, display: "flex", flexDirection: "row" },
     bottomRow: {
-        justifyContent: "flex-end",
+        justifyContent: "space-between",
         flexBasis: "30%",
         display: "flex",
         flexDirection: "row",
     },
-    leftCol: { justifyContent: "flex-start", flexBasis: "36%" },
-    middleCol: { flex: 1 },
-    rightCol: { justifyContent: "space-evenly", flexBasis: "25%" },
-    bottomAlign: { marginTop: "auto" },
+    leftCol: { flexBasis: "32%", textAlign: "left" },
+    middleCol: { flex: 1, textAlign: "left" },
+    rightCol: { flexBasis: "28%", textAlign: "right"},
+    bottomAlign: { marginTop: "13px"},
     headingText: { fontFamily: "Helvetica-Bold", textTransform: "uppercase" },
     largeText: {
-        fontSize: "29pt",
+        fontSize: "20pt",
         lineHeight: 1,
     },
     mediumText: {
-        fontSize: "19pt",
+        fontSize: "15pt",
         lineHeight: 1,
     },
 });
@@ -81,20 +83,22 @@ interface LabelCardProps {
 const SingleLabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) => {
     return (
         <Page size={labelSizePixels} style={styles.page}>
-            <View style={styles.cardWrapper} wrap={false}>
-                <View style={styles.topRow}>
-                    <Text style={styles.leftCol}>
-                        <Text style={styles.headingText}>Name:</Text>
-                        <Text> {data.full_name}</Text>
-                    </Text>
-                    <Text style={styles.middleCol}>
-                        <Text style={styles.headingText}>Contact:</Text>
-                        <Text> {data.phone_number}</Text>
-                    </Text>
-                    <Text style={styles.rightCol}>
-                        <Text style={styles.headingText}>Packed:</Text>
-                        <Text>{data.packing_date} {data.packing_slot}</Text>
-                    </Text>
+            <View style={styles.cardWrapper} wrap={true}>
+                <View style={[styles.topRow]}>
+                    <View style={[styles.leftCol, {flexDirection: "row"}]}>
+                        <Text style={styles.headingText}>Name: </Text>
+                        <Text>{data.full_name}</Text>
+                    </View>
+                    <View style={[styles.middleCol, {flexDirection: "row"}]}>
+                        <Text style={styles.headingText}>Contact: </Text>
+                        <Text>{data.phone_number}</Text>
+                    </View>
+                    <View style={[styles.rightCol]}>
+                        <View style={{flexDirection: "row", justifyContent: "flex-end"}}>
+                            <Text style={[styles.headingText]}>Packed:{" "}</Text>
+                            <Text>{data.packing_date}</Text>
+                        </View>    
+                    </View>
                 </View>
                 <View style={styles.middleRow}>
                     <View style={styles.leftCol}>
@@ -120,34 +124,44 @@ const SingleLabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) =>
                         )}
                     </View>
                     <View style={styles.middleCol}>
-                        <Text style={styles.headingText}>Delivery Instructions:</Text>
+                        <Text style={styles.headingText}>Delivery Instructions: </Text>
                         <Text>{data.delivery_instructions}</Text>
                     </View>
                 </View>
-                <View style={styles.bottomRow}>
-                    <View style={[styles.leftCol, styles.bottomAlign]}>
+                <View style={[styles.bottomRow]}>
+                    <View style={[styles.leftCol, {marginTop: "10px"}]}>
                         <Text style={styles.largeText}>
                             {data.address_postcode ?? nullPostcodeDisplay}
                         </Text>
                     </View>
-                    <View style={[styles.middleCol, styles.bottomAlign, { flexDirection: "row" }]}>
-                        <Text style={styles.mediumText}>
-                            {data.packing_slot} |
-                            {data.collection_centre === "DLVR"
-                                ? "Delivery "
-                                : data.collection_centre + " "}
-                        </Text>
-                        <FontAwesomeIconPdfComponent
-                            faIcon={
-                                data.collection_centre === "DLVR"
-                                    ? faTruck
-                                    : faBuildingCircleArrowRight
-                            }
-                        ></FontAwesomeIconPdfComponent>
+                    <View style={[styles.middleCol, { flexDirection: "row"}]}>
+                        <View style = {[styles.bottomAlign]}>
+                            <Text style={styles.mediumText}>
+                                {data.packing_slot}{" "} 
+                            </Text>
+                        </View>
+                        <View style = {{marginTop: "auto"}}>
+                            <Text style={{fontWeight: "bold", fontSize: "20pt"}}>|</Text>
+                        </View>
+                        <View style = {[styles.bottomAlign, { flexDirection: "row" }]}>
+                            <Text style={styles.mediumText}>
+                                {" "}
+                                {data.collection_centre === "DLVR"
+                                    ? "Delivery "
+                                    : data.collection_centre + " "}
+                            </Text>
+                            <FontAwesomeIconPdfComponent
+                                faIcon={
+                                    data.collection_centre === "DLVR"
+                                        ? faTruck
+                                        : faShoePrints
+                                }
+                            ></FontAwesomeIconPdfComponent>
+                        </View>
                     </View>
                     <View style={[styles.rightCol, styles.bottomAlign]}>
                         <Text style={styles.mediumText}>
-                            Parcel {index + 1} of {quantity}
+                            {index + 1} of {quantity}
                         </Text>
                     </View>
                 </View>

--- a/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
+++ b/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
@@ -7,6 +7,7 @@ import FontAwesomeIconPdfComponent from "@/pdf/FontAwesomeIconPdfComponent";
 export interface ShippingLabelData {
     label_quantity: number;
     parcel_id: string;
+    packing_date: string;
     packing_slot: string;
     collection_centre: string;
     collection_datetime: string;
@@ -40,12 +41,14 @@ const styles = StyleSheet.create({
         height: "100%",
         display: "flex",
         flexDirection: "column",
+        padding: "0.2cm",
     },
     topRow: {
         justifyContent: "flex-start",
         flexBasis: "20%",
         display: "flex",
         flexDirection: "row",
+
     },
     middleRow: { flex: 1, display: "flex", flexDirection: "row" },
     bottomRow: {
@@ -56,7 +59,7 @@ const styles = StyleSheet.create({
     },
     leftCol: { justifyContent: "flex-start", flexBasis: "36%" },
     middleCol: { flex: 1 },
-    rightCol: { justifyContent: "flex-end", flexBasis: "25%" },
+    rightCol: { justifyContent: "space-evenly", flexBasis: "25%" },
     bottomAlign: { marginTop: "auto" },
     headingText: { fontFamily: "Helvetica-Bold", textTransform: "uppercase" },
     largeText: {
@@ -90,7 +93,7 @@ const SingleLabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) =>
                     </Text>
                     <Text style={styles.rightCol}>
                         <Text style={styles.headingText}>Packed:</Text>
-                        <Text> {data.packing_slot}</Text>
+                        <Text>{data.packing_date} {data.packing_slot}</Text>
                     </Text>
                 </View>
                 <View style={styles.middleRow}>

--- a/src/pdf/ShippingLabels/ShippingLabelsPdfButton.tsx
+++ b/src/pdf/ShippingLabels/ShippingLabelsPdfButton.tsx
@@ -126,6 +126,7 @@ const getRequiredData = async (
         parcelDataList.push({
             label_quantity: labelQuantity,
             parcel_id: parcelId,
+            packing_date: parcel.packing_date ?? "",
             packing_slot: parcel.packing_slot?.name ?? "",
             collection_centre: parcel.collection_centre?.acronym ?? "",
             collection_datetime: formatDatetime(parcel.collection_datetime),


### PR DESCRIPTION
## What's changed

- Added padding between border and text so text now appear further away from border
- Top right of label has been changed to packing date instead of time of day (i.e. AM/PM) as this is displayed at the bottom center of the label
- "Packed: [packing date]" has been aligned right
- Bottom right has been right aligned and also changed to just "1 of 1" (previously "Item/Parcel 1 of 4")
- Collection icon has been switched to the feet icon
- Method: | line has been bolded and sized up to increase clarity
- Label has been changed to 200mm x 62mm as required (previously 150mm x 62mm)
- Column spacings have been slightly modified to improve clarity

## Screenshots / Videos
| Before     | After      |
|------------|------------|
|![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985277/04cadd8c-69db-4d4f-9150-e4c414f0f2b0)|![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985277/25799e00-2903-4c02-958d-b718ccf10b25)|
|![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985277/c4b40df1-8305-4986-b40f-4e2fb15e62bc)|![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985277/080506a7-d094-4b46-93ea-3dc59dbc2e56)|



## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [ ] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... (no changes)
